### PR TITLE
Fix EXTINF and URI displaying bug

### DIFF
--- a/src/media_playlist.rs
+++ b/src/media_playlist.rs
@@ -277,7 +277,7 @@ impl fmt::Display for MediaPlaylist {
             writeln!(f, "{}", t)?;
         }
         for segment in &self.segments {
-            writeln!(f, "{}", segment)?;
+            write!(f, "{}", segment)?;
         }
         if let Some(ref t) = self.end_list_tag {
             writeln!(f, "{}", t)?;

--- a/src/media_segment.rs
+++ b/src/media_segment.rs
@@ -108,7 +108,7 @@ impl fmt::Display for MediaSegment {
         if let Some(ref t) = self.program_date_time_tag {
             writeln!(f, "{}", t)?;
         }
-        writeln!(f, "{}", self.inf_tag)?;
+        writeln!(f, "{},", self.inf_tag)?;
         writeln!(f, "{}", self.uri)?;
         Ok(())
     }


### PR DESCRIPTION
Remove unnecessary empty lines.
EXTINF tag with comma.

Before: 
> #EXTINF:9.009
> 10.ts
> 
> #EXTINF:9.009
> 11.ts
> 
> #EXTINF:9.003
> 12.ts

After:
> #EXTINF:9.009,
> 10.ts
> #EXTINF:9.009,
> 11.ts
> #EXTINF:9.003,
> 12.ts

