### PR TITLE
fix rfc8216_8-7.m3u8 parsing bug

### DIFF
--- a/src/tags/master_playlist/media.rs
+++ b/src/tags/master_playlist/media.rs
@@ -126,9 +126,10 @@ impl ExtXMediaBuilder {
             return Err(Error::unexpected_attribute("INSTREAM-ID").to_string());
         }
 
-        if self.is_default.unwrap_or(false) && !self.is_autoselect.unwrap_or(false) {
+        if self.is_default.unwrap_or(false) && !self.is_autoselect.unwrap_or(true) {
             return Err(
-                Error::custom("If `DEFAULT` is true, `AUTOSELECT` has to be true too!").to_string(),
+                Error::custom("If `DEFAULT` is true and `AUTOSELECT` is present, \
+                               `AUTOSELECT` has to be true too!").to_string(),
             );
         }
 


### PR DESCRIPTION
rfc8216 says
> **If the AUTOSELECT attribute is present**, its value MUST be YES if
> the value of the DEFAULT attribute is YES.
