### PR TITLE
drop feature option_flattening

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![forbid(unsafe_code)]
-#![feature(option_flattening)]
 #![warn(
     //clippy::pedantic,
     clippy::nursery,


### PR DESCRIPTION
rust nightly yells

warning: the feature `option_flattening` has been stable since 1.40.0 and no longer requires an attribute to enable

and it's not even possible compile source code with stable rust. If
option_flattening is dropped, it now compiles with stable and nightly rust.

Signed-off-by: Nikola Pajkovsky <nikola.pajkovsky@livesporttv.cz>