### PR TITLE
Further performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# hls_m3u8
+
+## {next}
+
+ * Performance improvements:
+    + Changed `MediaPlaylist::segments` from `BTreeMap<usize, MediaSegment>`
+      to `StableVec<MediaSegment>`
+    + Added `perf` feature, which can be used to improve performance in the future
+    + Changed all instances of `String` to `Cow<'a, str>` to reduce `Clone`-ing.
+
+ * Most structs now implement [`TryFrom<&'a str>`][TryFrom] instead of [`FromStr`][FromStr].
+
+
+[TryFrom]: https://doc.rust-lang.org/std/convert/trait.TryFrom.html
+[FromStr]: https://doc.rust-lang.org/std/str/trait.FromStr.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = "1.0"
 derive_more = "0.99"
 shorthand = "0.1"
 strum = { version = "0.17", features = ["derive"] }
+
 stable-vec = { version = "0.4" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ categories = ["parser-implementations"]
 
 [features]
 default = []
+perf = []
+
 [badges]
 codecov = { repository = "sile/hls_m3u8" }
 travis-ci = { repository = "sile/hls_m3u8" }

--- a/benches/benchmarks/media_playlist.rs
+++ b/benches/benchmarks/media_playlist.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -58,7 +59,7 @@ fn create_manifest_data() -> Vec<u8> {
     builder.build().unwrap().to_string().into_bytes()
 }
 
-fn criterion_benchmark(c: &mut Criterion) {
+fn media_playlist_from_str(c: &mut Criterion) {
     let data = String::from_utf8(create_manifest_data()).unwrap();
 
     let mut group = c.benchmark_group("MediaPlaylist::from_str");
@@ -72,4 +73,18 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, criterion_benchmark);
+fn media_playlist_try_from(c: &mut Criterion) {
+    let data = String::from_utf8(create_manifest_data()).unwrap();
+
+    let mut group = c.benchmark_group("MediaPlaylist::try_from");
+
+    group.throughput(Throughput::Bytes(data.len() as u64));
+
+    group.bench_function("MediaPlaylist::try_from", |b| {
+        b.iter(|| MediaPlaylist::try_from(black_box(data.as_str())).unwrap());
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, media_playlist_from_str, media_playlist_try_from);

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -30,7 +30,7 @@ impl<'a> Iterator for AttributePairs<'a> {
             // NOTE: it is okay to add 1 to the index, because an `=` is exactly 1 byte.
             self.index = end + 1;
 
-            ::core::str::from_utf8(&self.string.as_bytes()[start..end]).unwrap()
+            &self.string[start..end]
         };
 
         let value = {
@@ -66,7 +66,7 @@ impl<'a> Iterator for AttributePairs<'a> {
             self.index += end;
             self.index -= start;
 
-            ::core::str::from_utf8(&self.string.as_bytes()[start..end]).unwrap()
+            &self.string[start..end]
         };
 
         Some((key, value))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,19 +42,22 @@
 //!
 //! ```
 //! use hls_m3u8::MediaPlaylist;
+//! use std::convert::TryFrom;
 //!
-//! let m3u8 = "#EXTM3U
-//! #EXT-X-TARGETDURATION:10
-//! #EXT-X-VERSION:3
-//! #EXTINF:9.009,
-//! http://media.example.com/first.ts
-//! #EXTINF:9.009,
-//! http://media.example.com/second.ts
-//! #EXTINF:3.003,
-//! http://media.example.com/third.ts
-//! #EXT-X-ENDLIST";
+//! let m3u8 = MediaPlaylist::try_from(concat!(
+//!     "#EXTM3U\n",
+//!     "#EXT-X-TARGETDURATION:10\n",
+//!     "#EXT-X-VERSION:3\n",
+//!     "#EXTINF:9.009,\n",
+//!     "http://media.example.com/first.ts\n",
+//!     "#EXTINF:9.009,\n",
+//!     "http://media.example.com/second.ts\n",
+//!     "#EXTINF:3.003,\n",
+//!     "http://media.example.com/third.ts\n",
+//!     "#EXT-X-ENDLIST",
+//! ));
 //!
-//! assert!(m3u8.parse::<MediaPlaylist>().is_ok());
+//! assert!(m3u8.is_ok());
 //! ```
 //!
 //! ## Crate Feature Flags

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,6 +1,5 @@
 use core::convert::TryFrom;
 use core::iter::FusedIterator;
-use core::str::FromStr;
 
 use derive_more::Display;
 
@@ -23,7 +22,8 @@ impl<'a> Iterator for Lines<'a> {
             let uri = self.lines.next()?;
 
             Some(
-                tags::VariantStream::from_str(&format!("{}\n{}", line, uri))
+                tags::VariantStream::try_from(format!("{}\n{}", line, uri).as_str())
+                    .map(|v| v.into_owned())
                     .map(|v| Line::Tag(Tag::VariantStream(v))),
             )
         } else if line.starts_with("#EXT") {
@@ -60,25 +60,25 @@ pub(crate) enum Line<'a> {
 #[display(fmt = "{}")]
 pub(crate) enum Tag<'a> {
     ExtXVersion(tags::ExtXVersion),
-    ExtInf(tags::ExtInf),
+    ExtInf(tags::ExtInf<'a>),
     ExtXByteRange(tags::ExtXByteRange),
     ExtXDiscontinuity(tags::ExtXDiscontinuity),
-    ExtXKey(tags::ExtXKey),
-    ExtXMap(tags::ExtXMap),
-    ExtXProgramDateTime(tags::ExtXProgramDateTime),
-    ExtXDateRange(tags::ExtXDateRange),
+    ExtXKey(tags::ExtXKey<'a>),
+    ExtXMap(tags::ExtXMap<'a>),
+    ExtXProgramDateTime(tags::ExtXProgramDateTime<'a>),
+    ExtXDateRange(tags::ExtXDateRange<'a>),
     ExtXTargetDuration(tags::ExtXTargetDuration),
     ExtXMediaSequence(tags::ExtXMediaSequence),
     ExtXDiscontinuitySequence(tags::ExtXDiscontinuitySequence),
     ExtXEndList(tags::ExtXEndList),
     PlaylistType(PlaylistType),
     ExtXIFramesOnly(tags::ExtXIFramesOnly),
-    ExtXMedia(tags::ExtXMedia),
-    ExtXSessionData(tags::ExtXSessionData),
-    ExtXSessionKey(tags::ExtXSessionKey),
+    ExtXMedia(tags::ExtXMedia<'a>),
+    ExtXSessionData(tags::ExtXSessionData<'a>),
+    ExtXSessionKey(tags::ExtXSessionKey<'a>),
     ExtXIndependentSegments(tags::ExtXIndependentSegments),
     ExtXStart(tags::ExtXStart),
-    VariantStream(tags::VariantStream),
+    VariantStream(tags::VariantStream<'a>),
     Unknown(&'a str),
 }
 
@@ -87,47 +87,47 @@ impl<'a> TryFrom<&'a str> for Tag<'a> {
 
     fn try_from(input: &'a str) -> Result<Self, Self::Error> {
         if input.starts_with(tags::ExtXVersion::PREFIX) {
-            input.parse().map(Self::ExtXVersion)
+            TryFrom::try_from(input).map(Self::ExtXVersion)
         } else if input.starts_with(tags::ExtInf::PREFIX) {
-            input.parse().map(Self::ExtInf)
+            TryFrom::try_from(input).map(Self::ExtInf)
         } else if input.starts_with(tags::ExtXByteRange::PREFIX) {
-            input.parse().map(Self::ExtXByteRange)
+            TryFrom::try_from(input).map(Self::ExtXByteRange)
         } else if input.starts_with(tags::ExtXDiscontinuity::PREFIX) {
-            input.parse().map(Self::ExtXDiscontinuity)
+            TryFrom::try_from(input).map(Self::ExtXDiscontinuity)
         } else if input.starts_with(tags::ExtXKey::PREFIX) {
-            input.parse().map(Self::ExtXKey)
+            TryFrom::try_from(input).map(Self::ExtXKey)
         } else if input.starts_with(tags::ExtXMap::PREFIX) {
-            input.parse().map(Self::ExtXMap)
+            TryFrom::try_from(input).map(Self::ExtXMap)
         } else if input.starts_with(tags::ExtXProgramDateTime::PREFIX) {
-            input.parse().map(Self::ExtXProgramDateTime)
+            TryFrom::try_from(input).map(Self::ExtXProgramDateTime)
         } else if input.starts_with(tags::ExtXTargetDuration::PREFIX) {
-            input.parse().map(Self::ExtXTargetDuration)
+            TryFrom::try_from(input).map(Self::ExtXTargetDuration)
         } else if input.starts_with(tags::ExtXDateRange::PREFIX) {
-            input.parse().map(Self::ExtXDateRange)
+            TryFrom::try_from(input).map(Self::ExtXDateRange)
         } else if input.starts_with(tags::ExtXMediaSequence::PREFIX) {
-            input.parse().map(Self::ExtXMediaSequence)
+            TryFrom::try_from(input).map(Self::ExtXMediaSequence)
         } else if input.starts_with(tags::ExtXDiscontinuitySequence::PREFIX) {
-            input.parse().map(Self::ExtXDiscontinuitySequence)
+            TryFrom::try_from(input).map(Self::ExtXDiscontinuitySequence)
         } else if input.starts_with(tags::ExtXEndList::PREFIX) {
-            input.parse().map(Self::ExtXEndList)
+            TryFrom::try_from(input).map(Self::ExtXEndList)
         } else if input.starts_with(PlaylistType::PREFIX) {
-            input.parse().map(Self::PlaylistType)
+            TryFrom::try_from(input).map(Self::PlaylistType)
         } else if input.starts_with(tags::ExtXIFramesOnly::PREFIX) {
-            input.parse().map(Self::ExtXIFramesOnly)
+            TryFrom::try_from(input).map(Self::ExtXIFramesOnly)
         } else if input.starts_with(tags::ExtXMedia::PREFIX) {
-            input.parse().map(Self::ExtXMedia)
+            TryFrom::try_from(input).map(Self::ExtXMedia)
         } else if input.starts_with(tags::VariantStream::PREFIX_EXTXIFRAME)
             || input.starts_with(tags::VariantStream::PREFIX_EXTXSTREAMINF)
         {
-            input.parse().map(Self::VariantStream)
+            TryFrom::try_from(input).map(Self::VariantStream)
         } else if input.starts_with(tags::ExtXSessionData::PREFIX) {
-            input.parse().map(Self::ExtXSessionData)
+            TryFrom::try_from(input).map(Self::ExtXSessionData)
         } else if input.starts_with(tags::ExtXSessionKey::PREFIX) {
-            input.parse().map(Self::ExtXSessionKey)
+            TryFrom::try_from(input).map(Self::ExtXSessionKey)
         } else if input.starts_with(tags::ExtXIndependentSegments::PREFIX) {
-            input.parse().map(Self::ExtXIndependentSegments)
+            TryFrom::try_from(input).map(Self::ExtXIndependentSegments)
         } else if input.starts_with(tags::ExtXStart::PREFIX) {
-            input.parse().map(Self::ExtXStart)
+            TryFrom::try_from(input).map(Self::ExtXStart)
         } else {
             Ok(Self::Unknown(input))
         }

--- a/src/tags/basic/m3u.rs
+++ b/src/tags/basic/m3u.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 
 use crate::types::ProtocolVersion;
 use crate::utils::tag;
@@ -28,10 +28,10 @@ impl fmt::Display for ExtM3u {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", Self::PREFIX) }
 }
 
-impl FromStr for ExtM3u {
-    type Err = Error;
+impl TryFrom<&str> for ExtM3u {
+    type Error = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         tag(input, Self::PREFIX)?;
         Ok(Self)
     }
@@ -49,8 +49,8 @@ mod test {
 
     #[test]
     fn test_parser() {
-        assert_eq!("#EXTM3U".parse::<ExtM3u>().unwrap(), ExtM3u);
-        assert!("#EXTM2U".parse::<ExtM3u>().is_err());
+        assert_eq!(ExtM3u::try_from("#EXTM3U").unwrap(), ExtM3u);
+        assert!(ExtM3u::try_from("#EXTM2U").is_err());
     }
 
     #[test]

--- a/src/tags/basic/version.rs
+++ b/src/tags/basic/version.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 
 use crate::types::ProtocolVersion;
 use crate::utils::tag;
@@ -67,10 +67,10 @@ impl From<ProtocolVersion> for ExtXVersion {
     fn from(value: ProtocolVersion) -> Self { Self(value) }
 }
 
-impl FromStr for ExtXVersion {
-    type Err = Error;
+impl TryFrom<&str> for ExtXVersion {
+    type Error = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         let version = tag(input, Self::PREFIX)?.parse()?;
         Ok(Self::new(version))
     }
@@ -92,7 +92,7 @@ mod test {
     #[test]
     fn test_parser() {
         assert_eq!(
-            "#EXT-X-VERSION:6".parse::<ExtXVersion>().unwrap(),
+            ExtXVersion::try_from("#EXT-X-VERSION:6").unwrap(),
             ExtXVersion::new(ProtocolVersion::V6)
         );
     }

--- a/src/tags/media_playlist/discontinuity_sequence.rs
+++ b/src/tags/media_playlist/discontinuity_sequence.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 
 use crate::types::ProtocolVersion;
 use crate::utils::tag;
@@ -28,10 +28,10 @@ impl fmt::Display for ExtXDiscontinuitySequence {
     }
 }
 
-impl FromStr for ExtXDiscontinuitySequence {
-    type Err = Error;
+impl TryFrom<&str> for ExtXDiscontinuitySequence {
+    type Error = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         let input = tag(input, Self::PREFIX)?;
         let seq_num = input.parse().map_err(|e| Error::parse_int(input, e))?;
 
@@ -64,11 +64,11 @@ mod test {
     fn test_parser() {
         assert_eq!(
             ExtXDiscontinuitySequence(123),
-            "#EXT-X-DISCONTINUITY-SEQUENCE:123".parse().unwrap()
+            ExtXDiscontinuitySequence::try_from("#EXT-X-DISCONTINUITY-SEQUENCE:123").unwrap()
         );
 
         assert_eq!(
-            ExtXDiscontinuitySequence::from_str("#EXT-X-DISCONTINUITY-SEQUENCE:12A"),
+            ExtXDiscontinuitySequence::try_from("#EXT-X-DISCONTINUITY-SEQUENCE:12A"),
             Err(Error::parse_int("12A", "12A".parse::<u64>().expect_err("")))
         );
     }

--- a/src/tags/media_playlist/end_list.rs
+++ b/src/tags/media_playlist/end_list.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 
 use crate::types::ProtocolVersion;
 use crate::utils::tag;
@@ -26,10 +26,10 @@ impl fmt::Display for ExtXEndList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { Self::PREFIX.fmt(f) }
 }
 
-impl FromStr for ExtXEndList {
-    type Err = Error;
+impl TryFrom<&str> for ExtXEndList {
+    type Error = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         tag(input, Self::PREFIX)?;
         Ok(Self)
     }
@@ -47,7 +47,10 @@ mod test {
 
     #[test]
     fn test_parser() {
-        assert_eq!(ExtXEndList, "#EXT-X-ENDLIST".parse().unwrap());
+        assert_eq!(
+            ExtXEndList,
+            ExtXEndList::try_from("#EXT-X-ENDLIST").unwrap()
+        );
     }
 
     #[test]

--- a/src/tags/media_playlist/i_frames_only.rs
+++ b/src/tags/media_playlist/i_frames_only.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 
 use crate::types::ProtocolVersion;
 use crate::utils::tag;
@@ -21,10 +21,10 @@ impl fmt::Display for ExtXIFramesOnly {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { Self::PREFIX.fmt(f) }
 }
 
-impl FromStr for ExtXIFramesOnly {
-    type Err = Error;
+impl TryFrom<&str> for ExtXIFramesOnly {
+    type Error = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         tag(input, Self::PREFIX)?;
         Ok(Self)
     }
@@ -44,7 +44,12 @@ mod test {
     }
 
     #[test]
-    fn test_parser() { assert_eq!(ExtXIFramesOnly, "#EXT-X-I-FRAMES-ONLY".parse().unwrap(),) }
+    fn test_parser() {
+        assert_eq!(
+            ExtXIFramesOnly,
+            ExtXIFramesOnly::try_from("#EXT-X-I-FRAMES-ONLY").unwrap(),
+        )
+    }
 
     #[test]
     fn test_required_version() {

--- a/src/tags/media_playlist/media_sequence.rs
+++ b/src/tags/media_playlist/media_sequence.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 
 use crate::types::ProtocolVersion;
 use crate::utils::tag;
@@ -26,10 +26,10 @@ impl fmt::Display for ExtXMediaSequence {
     }
 }
 
-impl FromStr for ExtXMediaSequence {
-    type Err = Error;
+impl TryFrom<&str> for ExtXMediaSequence {
+    type Error = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         let input = tag(input, Self::PREFIX)?;
         let seq_num = input.parse().map_err(|e| Error::parse_int(input, e))?;
 
@@ -62,7 +62,7 @@ mod test {
     fn test_parser() {
         assert_eq!(
             ExtXMediaSequence(123),
-            "#EXT-X-MEDIA-SEQUENCE:123".parse().unwrap()
+            ExtXMediaSequence::try_from("#EXT-X-MEDIA-SEQUENCE:123").unwrap()
         );
     }
 }

--- a/src/tags/media_playlist/target_duration.rs
+++ b/src/tags/media_playlist/target_duration.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 use std::time::Duration;
 
 use crate::types::ProtocolVersion;
@@ -25,10 +25,10 @@ impl fmt::Display for ExtXTargetDuration {
     }
 }
 
-impl FromStr for ExtXTargetDuration {
-    type Err = Error;
+impl TryFrom<&str> for ExtXTargetDuration {
+    type Error = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         let input = tag(input, Self::PREFIX)?
             .parse()
             .map_err(|e| Error::parse_int(input, e))?;
@@ -62,7 +62,7 @@ mod test {
     fn test_parser() {
         assert_eq!(
             ExtXTargetDuration(Duration::from_secs(5)),
-            "#EXT-X-TARGETDURATION:5".parse().unwrap()
+            ExtXTargetDuration::try_from("#EXT-X-TARGETDURATION:5").unwrap()
         );
     }
 }

--- a/src/tags/media_segment/byte_range.rs
+++ b/src/tags/media_segment/byte_range.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
@@ -187,13 +187,13 @@ impl fmt::Display for ExtXByteRange {
     }
 }
 
-impl FromStr for ExtXByteRange {
-    type Err = Error;
+impl TryFrom<&str> for ExtXByteRange {
+    type Error = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         let input = tag(input, Self::PREFIX)?;
 
-        Ok(Self(ByteRange::from_str(input)?))
+        Ok(Self(ByteRange::try_from(input)?))
     }
 }
 
@@ -219,12 +219,12 @@ mod test {
     fn test_parser() {
         assert_eq!(
             ExtXByteRange::from(2..15),
-            "#EXT-X-BYTERANGE:13@2".parse().unwrap()
+            ExtXByteRange::try_from("#EXT-X-BYTERANGE:13@2").unwrap()
         );
 
         assert_eq!(
             ExtXByteRange::from(..22),
-            "#EXT-X-BYTERANGE:22".parse().unwrap()
+            ExtXByteRange::try_from("#EXT-X-BYTERANGE:22").unwrap()
         );
     }
 

--- a/src/tags/media_segment/discontinuity.rs
+++ b/src/tags/media_segment/discontinuity.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 
 use crate::types::ProtocolVersion;
 use crate::utils::tag;
@@ -23,10 +23,10 @@ impl fmt::Display for ExtXDiscontinuity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { Self::PREFIX.fmt(f) }
 }
 
-impl FromStr for ExtXDiscontinuity {
-    type Err = Error;
+impl TryFrom<&str> for ExtXDiscontinuity {
+    type Error = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         tag(input, Self::PREFIX)?;
         Ok(Self)
     }
@@ -46,7 +46,12 @@ mod test {
     }
 
     #[test]
-    fn test_parser() { assert_eq!(ExtXDiscontinuity, "#EXT-X-DISCONTINUITY".parse().unwrap()) }
+    fn test_parser() {
+        assert_eq!(
+            ExtXDiscontinuity,
+            ExtXDiscontinuity::try_from("#EXT-X-DISCONTINUITY").unwrap()
+        )
+    }
 
     #[test]
     fn test_required_version() {

--- a/src/tags/shared/independent_segments.rs
+++ b/src/tags/shared/independent_segments.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 
 use crate::types::ProtocolVersion;
 use crate::utils::tag;
@@ -25,10 +25,10 @@ impl fmt::Display for ExtXIndependentSegments {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { Self::PREFIX.fmt(f) }
 }
 
-impl FromStr for ExtXIndependentSegments {
-    type Err = Error;
+impl TryFrom<&str> for ExtXIndependentSegments {
+    type Error = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         tag(input, Self::PREFIX)?;
         Ok(Self)
     }
@@ -51,7 +51,7 @@ mod test {
     fn test_parser() {
         assert_eq!(
             ExtXIndependentSegments,
-            "#EXT-X-INDEPENDENT-SEGMENTS".parse().unwrap(),
+            ExtXIndependentSegments::try_from("#EXT-X-INDEPENDENT-SEGMENTS").unwrap(),
         )
     }
 

--- a/src/tags/shared/start.rs
+++ b/src/tags/shared/start.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 
 use shorthand::ShortHand;
 
@@ -111,10 +111,10 @@ impl fmt::Display for ExtXStart {
     }
 }
 
-impl FromStr for ExtXStart {
-    type Err = Error;
+impl TryFrom<&str> for ExtXStart {
+    type Error = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         let input = tag(input, Self::PREFIX)?;
 
         let mut time_offset = None;
@@ -176,19 +176,17 @@ mod test {
     fn test_parser() {
         assert_eq!(
             ExtXStart::new(Float::new(-1.23)),
-            "#EXT-X-START:TIME-OFFSET=-1.23".parse().unwrap(),
+            ExtXStart::try_from("#EXT-X-START:TIME-OFFSET=-1.23").unwrap(),
         );
 
         assert_eq!(
             ExtXStart::with_precise(Float::new(1.23), true),
-            "#EXT-X-START:TIME-OFFSET=1.23,PRECISE=YES".parse().unwrap(),
+            ExtXStart::try_from("#EXT-X-START:TIME-OFFSET=1.23,PRECISE=YES").unwrap(),
         );
 
         assert_eq!(
             ExtXStart::with_precise(Float::new(1.23), true),
-            "#EXT-X-START:TIME-OFFSET=1.23,PRECISE=YES,UNKNOWN=TAG"
-                .parse()
-                .unwrap(),
+            ExtXStart::try_from("#EXT-X-START:TIME-OFFSET=1.23,PRECISE=YES,UNKNOWN=TAG").unwrap(),
         );
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,8 +6,8 @@ use crate::types::{DecryptionKey, ProtocolVersion};
 
 mod private {
     pub trait Sealed {}
-    impl Sealed for crate::MediaSegment {}
-    impl Sealed for crate::tags::ExtXMap {}
+    impl<'a> Sealed for crate::MediaSegment<'a> {}
+    impl<'a> Sealed for crate::tags::ExtXMap<'a> {}
 }
 
 /// Signals that a type or some of the asssociated data might need to be
@@ -16,7 +16,7 @@ mod private {
 /// # Note
 ///
 /// You are not supposed to implement this trait, therefore it is "sealed".
-pub trait Decryptable: private::Sealed {
+pub trait Decryptable<'a>: private::Sealed {
     /// Returns all keys, associated with the type.
     ///
     /// # Example
@@ -36,13 +36,13 @@ pub trait Decryptable: private::Sealed {
     /// }
     /// ```
     #[must_use]
-    fn keys(&self) -> Vec<&DecryptionKey>;
+    fn keys(&self) -> Vec<&DecryptionKey<'a>>;
 
     /// Most of the time only a single key is provided, so instead of iterating
     /// through all keys, one might as well just get the first key.
     #[must_use]
     #[inline]
-    fn first_key(&self) -> Option<&DecryptionKey> {
+    fn first_key(&self) -> Option<&DecryptionKey<'a>> {
         <Self as Decryptable>::keys(self).first().copied()
     }
 

--- a/src/types/codecs.rs
+++ b/src/types/codecs.rs
@@ -1,5 +1,6 @@
+use core::convert::TryFrom;
 use core::fmt;
-use core::str::FromStr;
+use std::borrow::Cow;
 
 use derive_more::{AsMut, AsRef, Deref, DerefMut};
 
@@ -25,11 +26,11 @@ use crate::Error;
 #[derive(
     AsMut, AsRef, Deref, DerefMut, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default,
 )]
-pub struct Codecs {
-    list: Vec<String>,
+pub struct Codecs<'a> {
+    list: Vec<Cow<'a, str>>,
 }
 
-impl Codecs {
+impl<'a> Codecs<'a> {
     /// Makes a new (empty) [`Codecs`] struct.
     ///
     /// # Example
@@ -41,9 +42,82 @@ impl Codecs {
     #[inline]
     #[must_use]
     pub const fn new() -> Self { Self { list: Vec::new() } }
+
+    /// Makes the struct independent of its lifetime, by taking ownership of all
+    /// internal [`Cow`]s.
+    ///
+    /// # Note
+    ///
+    /// This is a relatively expensive operation.
+    #[must_use]
+    pub fn into_owned(self) -> Codecs<'static> {
+        Codecs {
+            list: self
+                .list
+                .into_iter()
+                .map(|v| Cow::Owned(v.into_owned()))
+                .collect(),
+        }
+    }
 }
 
-impl fmt::Display for Codecs {
+impl<'a, T> From<Vec<T>> for Codecs<'a>
+where
+    T: Into<Cow<'a, str>>,
+{
+    fn from(value: Vec<T>) -> Self {
+        Self {
+            list: value.into_iter().map(|v| v.into()).collect(),
+        }
+    }
+}
+
+// TODO: this should be implemented with const generics in the future!
+macro_rules! implement_from {
+    ($($size:expr),*) => {
+        $(
+            impl<'a> From<[&'a str; $size]> for Codecs<'a> {
+                fn from(value: [&'a str; $size]) -> Self {
+                    Self {
+                        list: {
+                            let mut result = Vec::with_capacity($size);
+
+                            for i in 0..$size {
+                                result.push(Cow::Borrowed(value[i]))
+                            }
+
+                            result
+                        },
+                    }
+                }
+            }
+
+            impl<'a> From<&[&'a str; $size]> for Codecs<'a> {
+                fn from(value: &[&'a str; $size]) -> Self {
+                    Self {
+                        list: {
+                            let mut result = Vec::with_capacity($size);
+
+                            for i in 0..$size {
+                                result.push(Cow::Borrowed(value[i]))
+                            }
+
+                            result
+                        },
+                    }
+                }
+            }
+        )*
+    };
+}
+
+implement_from!(
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+    0x20
+);
+
+impl<'a> fmt::Display for Codecs<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(codec) = self.list.iter().next() {
             write!(f, "{}", codec)?;
@@ -56,20 +130,24 @@ impl fmt::Display for Codecs {
         Ok(())
     }
 }
-impl FromStr for Codecs {
-    type Err = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+impl<'a> TryFrom<&'a str> for Codecs<'a> {
+    type Error = Error;
+
+    fn try_from(input: &'a str) -> Result<Self, Self::Error> {
         Ok(Self {
             list: input.split(',').map(|s| s.into()).collect(),
         })
     }
 }
 
-impl<T: AsRef<str>, I: IntoIterator<Item = T>> From<I> for Codecs {
-    fn from(value: I) -> Self {
-        Self {
-            list: value.into_iter().map(|s| s.as_ref().to_string()).collect(),
+impl<'a> TryFrom<Cow<'a, str>> for Codecs<'a> {
+    type Error = Error;
+
+    fn try_from(input: Cow<'a, str>) -> Result<Self, Self::Error> {
+        match input {
+            Cow::Owned(o) => Ok(Codecs::try_from(o.as_str())?.into_owned()),
+            Cow::Borrowed(b) => Self::try_from(b),
         }
     }
 }
@@ -86,7 +164,7 @@ mod tests {
     #[test]
     fn test_display() {
         assert_eq!(
-            Codecs::from(vec!["mp4a.40.2", "avc1.4d401e"]).to_string(),
+            Codecs::from(["mp4a.40.2", "avc1.4d401e"]).to_string(),
             "mp4a.40.2,avc1.4d401e".to_string()
         );
     }
@@ -94,8 +172,8 @@ mod tests {
     #[test]
     fn test_parser() {
         assert_eq!(
-            Codecs::from_str("mp4a.40.2,avc1.4d401e").unwrap(),
-            Codecs::from(vec!["mp4a.40.2", "avc1.4d401e"])
+            Codecs::try_from("mp4a.40.2,avc1.4d401e").unwrap(),
+            Codecs::from(["mp4a.40.2", "avc1.4d401e"])
         );
     }
 }

--- a/src/types/playlist_type.rs
+++ b/src/types/playlist_type.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 
 use crate::types::ProtocolVersion;
 use crate::utils::tag;
@@ -43,10 +43,10 @@ impl fmt::Display for PlaylistType {
     }
 }
 
-impl FromStr for PlaylistType {
-    type Err = Error;
+impl TryFrom<&str> for PlaylistType {
+    type Error = Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         let input = tag(input, Self::PREFIX)?;
         match input {
             "EVENT" => Ok(Self::Event),
@@ -64,20 +64,18 @@ mod test {
     #[test]
     fn test_parser() {
         assert_eq!(
-            "#EXT-X-PLAYLIST-TYPE:VOD".parse::<PlaylistType>().unwrap(),
+            PlaylistType::try_from("#EXT-X-PLAYLIST-TYPE:VOD").unwrap(),
             PlaylistType::Vod,
         );
 
         assert_eq!(
-            "#EXT-X-PLAYLIST-TYPE:EVENT"
-                .parse::<PlaylistType>()
-                .unwrap(),
+            PlaylistType::try_from("#EXT-X-PLAYLIST-TYPE:EVENT").unwrap(),
             PlaylistType::Event,
         );
 
-        assert!("#EXT-X-PLAYLIST-TYPE:H".parse::<PlaylistType>().is_err());
+        assert!(PlaylistType::try_from("#EXT-X-PLAYLIST-TYPE:H").is_err());
 
-        assert!("garbage".parse::<PlaylistType>().is_err());
+        assert!(PlaylistType::try_from("garbage").is_err());
     }
 
     #[test]

--- a/tests/master_playlist.rs
+++ b/tests/master_playlist.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use hls_m3u8::tags::{ExtXMedia, VariantStream};
 use hls_m3u8::types::{MediaType, StreamData};
 use hls_m3u8::MasterPlaylist;
@@ -9,7 +11,7 @@ macro_rules! generate_tests {
         $(
             #[test]
             fn $fnname() {
-                assert_eq!($struct, $str.parse().unwrap());
+                assert_eq!($struct, TryFrom::try_from($str).unwrap());
 
                 assert_eq!($struct.to_string(), $str.to_string());
             }

--- a/tests/media_playlist.rs
+++ b/tests/media_playlist.rs
@@ -3,6 +3,7 @@
 //!
 //! TODO: the rest of the tests
 
+use std::convert::TryFrom;
 use std::time::Duration;
 
 use hls_m3u8::tags::{ExtInf, ExtXByteRange};
@@ -15,7 +16,7 @@ macro_rules! generate_tests {
         $(
             #[test]
             fn $fnname() {
-                assert_eq!($struct, $str.parse().unwrap());
+                assert_eq!($struct, TryFrom::try_from($str).unwrap());
 
                 assert_eq!($struct.to_string(), $str.to_string());
             }

--- a/tests/rfc8216.rs
+++ b/tests/rfc8216.rs
@@ -1,4 +1,5 @@
 // https://tools.ietf.org/html/rfc8216#section-8
+use std::convert::TryFrom;
 use std::time::Duration;
 
 use hls_m3u8::tags::{ExtInf, ExtXKey, ExtXMedia, VariantStream};
@@ -11,7 +12,7 @@ macro_rules! generate_tests {
         $(
             #[test]
             fn $fnname() {
-                assert_eq!($struct, $str.parse().unwrap());
+                assert_eq!($struct, TryFrom::try_from($str).unwrap());
 
                 assert_eq!($struct.to_string(), $str.to_string());
             }


### PR DESCRIPTION
- Added `perf` feature
- Switched most structs from `FromStr` to `TryFrom<&'a str>`
- Replaced all instances of `String` with `Cow<'a, str>`
- Added changelog