### PR TITLE
Fix build errors on rustc-1.45.2

### DIFF
--- a/src/types/initialization_vector.rs
+++ b/src/types/initialization_vector.rs
@@ -52,7 +52,7 @@ impl InitializationVector {
     /// assert_eq!(InitializationVector::Missing.to_u128(), None);
     /// ```
     #[must_use]
-    pub const fn to_u128(&self) -> Option<u128> {
+    pub fn to_u128(&self) -> Option<u128> {
         match *self {
             Self::Aes128(v) => Some(u128::from_be_bytes(v)),
             Self::Number(n) => Some(n),
@@ -93,7 +93,7 @@ impl InitializationVector {
     ///
     /// [`MediaSegment`]: crate::MediaSegment
     #[must_use]
-    pub const fn to_slice(&self) -> Option<[u8; 0x10]> {
+    pub fn to_slice(&self) -> Option<[u8; 0x10]> {
         match &self {
             Self::Aes128(v) => Some(*v),
             Self::Number(v) => Some(v.to_be_bytes()),

--- a/src/types/key_format_versions.rs
+++ b/src/types/key_format_versions.rs
@@ -144,7 +144,7 @@ impl KeyFormatVersions {
     /// the future this number might increase.
     #[inline]
     #[must_use]
-    pub const fn capacity(&self) -> usize { self.buffer.len() }
+    pub fn capacity(&self) -> usize { self.buffer.len() }
 
     /// Shortens the internal array to the provided length.
     ///


### PR DESCRIPTION
This PR fixes the following `const fn` related errors:
```rust
error[E0658]: `match` is not allowed in a `const fn`
  --> src/types/initialization_vector.rs:56:9
   |
56 | /         match *self {
57 | |             Self::Aes128(v) => Some(u128::from_be_bytes(v)),
58 | |             Self::Number(n) => Some(n),
59 | |             Self::Missing => None,
60 | |         }
   | |_________^
   |
   = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information

error[E0658]: `match` is not allowed in a `const fn`
   --> src/types/initialization_vector.rs:97:9
    |
97  | /         match &self {
98  | |             Self::Aes128(v) => Some(*v),
99  | |             Self::Number(v) => Some(v.to_be_bytes()),
100 | |             Self::Missing => None,
101 | |         }
    | |_________^
    |
    = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information

   --> src/types/key_format_versions.rs:147:45
    |
147 |     pub const fn capacity(&self) -> usize { self.buffer.len() }
    |                                             ^^^^^^^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
```