### PR TITLE
Fix warnings added over the last 3 years

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,7 @@
 #![doc(html_root_url = "https://docs.rs/hls_m3u8/0.4.1")]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms)]
-#![warn(
-    clippy::pedantic, //
-    clippy::nursery,
-    clippy::cargo,
-    clippy::inline_always,
-)]
+#![warn(clippy::cargo, clippy::inline_always)]
 #![allow(
     clippy::non_ascii_literal,
     clippy::redundant_pub_crate,
@@ -19,10 +14,10 @@
     clippy::clone_on_ref_ptr,
     clippy::decimal_literal_representation,
     clippy::get_unwrap,
-    clippy::expect_used,
     clippy::unneeded_field_pattern,
-    clippy::wrong_pub_self_convention
+    clippy::wrong_self_convention
 )]
+#![cfg_attr(not(test), warn(clippy::expect_used))]
 // those should not be present in production code:
 #![deny(
     clippy::print_stdout,

--- a/src/master_playlist.rs
+++ b/src/master_playlist.rs
@@ -68,7 +68,7 @@ use crate::{Error, RequiredVersion};
 ///             closed_captions: None,
 ///             stream_data: StreamData::builder()
 ///                 .bandwidth(150000)
-///                 .codecs(&["avc1.42e00a", "mp4a.40.2"])
+///                 .codecs(["avc1.42e00a", "mp4a.40.2"])
 ///                 .resolution((416, 234))
 ///                 .build()
 ///                 .unwrap(),
@@ -81,7 +81,7 @@ use crate::{Error, RequiredVersion};
 ///             closed_captions: None,
 ///             stream_data: StreamData::builder()
 ///                 .bandwidth(240000)
-///                 .codecs(&["avc1.42e00a", "mp4a.40.2"])
+///                 .codecs(["avc1.42e00a", "mp4a.40.2"])
 ///                 .resolution((416, 234))
 ///                 .build()
 ///                 .unwrap(),
@@ -190,7 +190,7 @@ impl<'a> MasterPlaylist<'a> {
     ///             closed_captions: None,
     ///             stream_data: StreamData::builder()
     ///                 .bandwidth(150000)
-    ///                 .codecs(&["avc1.42e00a", "mp4a.40.2"])
+    ///                 .codecs(["avc1.42e00a", "mp4a.40.2"])
     ///                 .resolution((416, 234))
     ///                 .build()
     ///                 .unwrap(),
@@ -203,7 +203,7 @@ impl<'a> MasterPlaylist<'a> {
     ///             closed_captions: None,
     ///             stream_data: StreamData::builder()
     ///                 .bandwidth(240000)
-    ///                 .codecs(&["avc1.42e00a", "mp4a.40.2"])
+    ///                 .codecs(["avc1.42e00a", "mp4a.40.2"])
     ///                 .resolution((416, 234))
     ///                 .build()
     ///                 .unwrap(),
@@ -262,7 +262,7 @@ impl<'a> MasterPlaylist<'a> {
     pub fn associated_with<'b>(
         &'b self,
         stream: &'b VariantStream<'_>,
-    ) -> impl Iterator<Item = &ExtXMedia<'a>> + 'b {
+    ) -> impl Iterator<Item = &'b ExtXMedia<'a>> + 'b {
         self.media
             .iter()
             .filter(move |media| stream.is_associated(media))
@@ -576,7 +576,7 @@ mod tests {
                 closed_captions: None,
                 stream_data: StreamData::builder()
                     .bandwidth(150_000)
-                    .codecs(&["avc1.42e00a", "mp4a.40.2"])
+                    .codecs(["avc1.42e00a", "mp4a.40.2"])
                     .resolution((416, 234))
                     .build()
                     .unwrap(),
@@ -589,7 +589,7 @@ mod tests {
                 closed_captions: None,
                 stream_data: StreamData::builder()
                     .bandwidth(240_000)
-                    .codecs(&["avc1.42e00a", "mp4a.40.2"])
+                    .codecs(["avc1.42e00a", "mp4a.40.2"])
                     .resolution((416, 234))
                     .build()
                     .unwrap(),
@@ -662,7 +662,7 @@ mod tests {
                         closed_captions: None,
                         stream_data: StreamData::builder()
                             .bandwidth(150_000)
-                            .codecs(&["avc1.42e00a", "mp4a.40.2"])
+                            .codecs(["avc1.42e00a", "mp4a.40.2"])
                             .resolution((416, 234))
                             .build()
                             .unwrap()
@@ -675,7 +675,7 @@ mod tests {
                         closed_captions: None,
                         stream_data: StreamData::builder()
                             .bandwidth(240_000)
-                            .codecs(&["avc1.42e00a", "mp4a.40.2"])
+                            .codecs(["avc1.42e00a", "mp4a.40.2"])
                             .resolution((416, 234))
                             .build()
                             .unwrap()
@@ -688,7 +688,7 @@ mod tests {
                         closed_captions: None,
                         stream_data: StreamData::builder()
                             .bandwidth(440_000)
-                            .codecs(&["avc1.42e00a", "mp4a.40.2"])
+                            .codecs(["avc1.42e00a", "mp4a.40.2"])
                             .resolution((416, 234))
                             .build()
                             .unwrap()
@@ -701,7 +701,7 @@ mod tests {
                         closed_captions: None,
                         stream_data: StreamData::builder()
                             .bandwidth(640_000)
-                            .codecs(&["avc1.42e00a", "mp4a.40.2"])
+                            .codecs(["avc1.42e00a", "mp4a.40.2"])
                             .resolution((640, 360))
                             .build()
                             .unwrap()
@@ -714,7 +714,7 @@ mod tests {
                         closed_captions: None,
                         stream_data: StreamData::builder()
                             .bandwidth(64000)
-                            .codecs(&["mp4a.40.5"])
+                            .codecs(["mp4a.40.5"])
                             .build()
                             .unwrap()
                     },
@@ -737,7 +737,7 @@ mod tests {
                         closed_captions: None,
                         stream_data: StreamData::builder()
                             .bandwidth(150_000)
-                            .codecs(&["avc1.42e00a", "mp4a.40.2"])
+                            .codecs(["avc1.42e00a", "mp4a.40.2"])
                             .resolution((416, 234))
                             .build()
                             .unwrap()
@@ -750,7 +750,7 @@ mod tests {
                         closed_captions: None,
                         stream_data: StreamData::builder()
                             .bandwidth(240_000)
-                            .codecs(&["avc1.42e00a", "mp4a.40.2"])
+                            .codecs(["avc1.42e00a", "mp4a.40.2"])
                             .resolution((416, 234))
                             .build()
                             .unwrap()
@@ -763,7 +763,7 @@ mod tests {
                         closed_captions: None,
                         stream_data: StreamData::builder()
                             .bandwidth(440_000)
-                            .codecs(&["avc1.42e00a", "mp4a.40.2"])
+                            .codecs(["avc1.42e00a", "mp4a.40.2"])
                             .resolution((416, 234))
                             .build()
                             .unwrap()
@@ -776,7 +776,7 @@ mod tests {
                         closed_captions: None,
                         stream_data: StreamData::builder()
                             .bandwidth(640_000)
-                            .codecs(&["avc1.42e00a", "mp4a.40.2"])
+                            .codecs(["avc1.42e00a", "mp4a.40.2"])
                             .resolution((640, 360))
                             .build()
                             .unwrap()
@@ -789,7 +789,7 @@ mod tests {
                         closed_captions: None,
                         stream_data: StreamData::builder()
                             .bandwidth(64000)
-                            .codecs(&["mp4a.40.5"])
+                            .codecs(["mp4a.40.5"])
                             .build()
                             .unwrap()
                     },

--- a/src/media_playlist.rs
+++ b/src/media_playlist.rs
@@ -56,7 +56,7 @@ pub struct MediaPlaylist<'a> {
     /// - [`PlaylistType::Vod`] indicates that the playlist must not change.
     ///
     /// - [`PlaylistType::Event`] indicates that the server does not change or
-    /// delete any part of the playlist, but may append new lines to it.
+    ///   delete any part of the playlist, but may append new lines to it.
     ///
     /// ### Note
     ///
@@ -367,7 +367,7 @@ impl<'a> MediaPlaylistBuilder<'a> {
             allowable_excess_duration: self
                 .allowable_excess_duration
                 .unwrap_or_else(|| Duration::from_secs(0)),
-            unknown: self.unknown.clone().unwrap_or_else(Vec::new),
+            unknown: self.unknown.clone().unwrap_or_default(),
         })
     }
 }

--- a/src/tags/basic/version.rs
+++ b/src/tags/basic/version.rs
@@ -11,7 +11,7 @@ use crate::{Error, RequiredVersion};
 ///
 /// [`MediaPlaylist`]: crate::MediaPlaylist
 /// [`MasterPlaylist`]: crate::MasterPlaylist
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct ExtXVersion(ProtocolVersion);
 
 impl ExtXVersion {
@@ -57,10 +57,6 @@ impl fmt::Display for ExtXVersion {
         //
         write!(f, "{}{}", Self::PREFIX, self.0)
     }
-}
-
-impl Default for ExtXVersion {
-    fn default() -> Self { Self(ProtocolVersion::default()) }
 }
 
 impl From<ProtocolVersion> for ExtXVersion {

--- a/src/tags/master_playlist/media.rs
+++ b/src/tags/master_playlist/media.rs
@@ -37,7 +37,7 @@ pub struct ExtXMedia<'a> {
     /// - This field is required, if the [`ExtXMedia::media_type`] is
     ///   [`MediaType::Subtitles`].
     /// - This field is not allowed, if the [`ExtXMedia::media_type`] is
-    /// [`MediaType::ClosedCaptions`].
+    ///   [`MediaType::ClosedCaptions`].
     ///
     /// An absent value indicates that the media data for this rendition is
     /// included in the [`MediaPlaylist`] of any
@@ -138,8 +138,8 @@ pub struct ExtXMedia<'a> {
     /// following characteristics:
     /// - `"public.accessibility.transcribes-spoken-dialog"`,
     /// - `"public.accessibility.describes-music-and-sound"`, and
-    /// - `"public.easy-to-read"` (which indicates that the subtitles have
-    /// been edited for ease of reading).
+    /// - `"public.easy-to-read"` (which indicates that the subtitles have been
+    ///   edited for ease of reading).
     ///
     /// An `ExtXMedia` instance with [`MediaType::Audio`] may include the
     /// following characteristic:
@@ -745,28 +745,18 @@ mod test {
 
     #[test]
     fn test_parser_error() {
-        assert_eq!(ExtXMedia::try_from("").is_err(), true);
-        assert_eq!(ExtXMedia::try_from("garbage").is_err(), true);
+        assert!(ExtXMedia::try_from("").is_err());
+        assert!(ExtXMedia::try_from("garbage").is_err());
 
-        assert_eq!(
-            ExtXMedia::try_from("#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,URI=\"http://www.example.com\"")
-                .is_err(),
-            true
-        );
-        assert_eq!(
-            ExtXMedia::try_from("#EXT-X-MEDIA:TYPE=AUDIO,INSTREAM-ID=CC1").is_err(),
-            true
-        );
+        assert!(ExtXMedia::try_from(
+            "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,URI=\"http://www.example.com\""
+        )
+        .is_err());
+        assert!(ExtXMedia::try_from("#EXT-X-MEDIA:TYPE=AUDIO,INSTREAM-ID=CC1").is_err());
 
-        assert_eq!(
-            ExtXMedia::try_from("#EXT-X-MEDIA:TYPE=AUDIO,DEFAULT=YES,AUTOSELECT=NO").is_err(),
-            true
-        );
+        assert!(ExtXMedia::try_from("#EXT-X-MEDIA:TYPE=AUDIO,DEFAULT=YES,AUTOSELECT=NO").is_err());
 
-        assert_eq!(
-            ExtXMedia::try_from("#EXT-X-MEDIA:TYPE=AUDIO,FORCED=YES").is_err(),
-            true
-        );
+        assert!(ExtXMedia::try_from("#EXT-X-MEDIA:TYPE=AUDIO,FORCED=YES").is_err());
     }
 
     #[test]

--- a/src/tags/master_playlist/session_key.rs
+++ b/src/tags/master_playlist/session_key.rs
@@ -75,7 +75,7 @@ impl<'a> RequiredVersion for ExtXSessionKey<'a> {
 
 impl<'a> fmt::Display for ExtXSessionKey<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}", Self::PREFIX, self.0.to_string())
+        write!(f, "{}{}", Self::PREFIX, self.0)
     }
 }
 

--- a/src/tags/media_segment/byte_range.rs
+++ b/src/tags/media_segment/byte_range.rs
@@ -137,6 +137,7 @@ impl RequiredVersion for ExtXByteRange {
     fn required_version(&self) -> ProtocolVersion { ProtocolVersion::V4 }
 }
 
+#[allow(clippy::from_over_into)] // Some magic `From` blanket impl is going on that means this can't be done.
 impl Into<ByteRange> for ExtXByteRange {
     fn into(self) -> ByteRange { self.0 }
 }

--- a/src/tags/media_segment/date_range.rs
+++ b/src/tags/media_segment/date_range.rs
@@ -502,7 +502,7 @@ impl<'a> fmt::Display for ExtXDateRange<'a> {
 
             #[cfg(not(feature = "chrono"))]
             {
-                write!(f, ",START-DATE={}", quote(&value))?;
+                write!(f, ",START-DATE={}", quote(value))?;
             }
         }
 
@@ -518,7 +518,7 @@ impl<'a> fmt::Display for ExtXDateRange<'a> {
 
             #[cfg(not(feature = "chrono"))]
             {
-                write!(f, ",END-DATE={}", quote(&value))?;
+                write!(f, ",END-DATE={}", quote(value))?;
             }
         }
 

--- a/src/tags/media_segment/inf.rs
+++ b/src/tags/media_segment/inf.rs
@@ -182,7 +182,7 @@ impl<'a> TryFrom<&'a str> for ExtInf<'a> {
             .next()
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .map(|v| Cow::Borrowed(v));
+            .map(Cow::Borrowed);
 
         Ok(Self { duration, title })
     }

--- a/src/types/byte_range.rs
+++ b/src/types/byte_range.rs
@@ -122,7 +122,7 @@ impl ByteRange {
     ///
     /// ```
     /// # use hls_m3u8::types::ByteRange;
-    /// let range = ByteRange::from(5..usize::max_value());
+    /// let range = ByteRange::from(5..usize::MAX);
     ///
     /// // this would cause the end to overflow
     /// let nrange = range.saturating_add(1);
@@ -145,10 +145,10 @@ impl ByteRange {
             } else {
                 // it is ensured at construction that the start will never be larger than the
                 // end. This clause can therefore be only reached if the end overflowed.
-                // -> It is only possible to add `usize::max_value() - end` to the start.
-                if let Some(start) = start.checked_add(usize::max_value() - self.end) {
+                // -> It is only possible to add `usize::MAX - end` to the start.
+                if let Some(start) = start.checked_add(usize::MAX - self.end) {
                     self.start = Some(start);
-                    self.end = usize::max_value();
+                    self.end = usize::MAX;
                 } else {
                     // both end + start overflowed -> do not change anything
                 }
@@ -351,7 +351,6 @@ macro_rules! impl_from_ranges {
 // stable (`Into<i64> for usize` is reserved for upstream crates ._.)
 impl_from_ranges![u64, u32, u16, u8, usize, i32];
 
-#[must_use]
 impl RangeBounds<usize> for ByteRange {
     fn start_bound(&self) -> Bound<&usize> {
         self.start
@@ -488,7 +487,7 @@ mod tests {
     #[test]
     #[should_panic = "attempt to add with overflow"]
     fn test_add_assign_panic() {
-        let mut range = ByteRange::from(4..usize::max_value());
+        let mut range = ByteRange::from(4..usize::MAX);
         range += 5;
 
         unreachable!();
@@ -529,7 +528,7 @@ mod tests {
 
     #[test]
     #[should_panic = "attempt to add with overflow"]
-    fn test_add_panic() { let _ = ByteRange::from(usize::max_value()..usize::max_value()) + 1; }
+    fn test_add_panic() { let _ = ByteRange::from(usize::MAX..usize::MAX) + 1; }
 
     #[test]
     #[allow(clippy::identity_op)]
@@ -580,28 +579,28 @@ mod tests {
 
         // overflow
         assert_eq!(
-            ByteRange::from(usize::max_value()..usize::max_value()).saturating_add(1),
-            ByteRange::from(usize::max_value()..usize::max_value())
+            ByteRange::from(usize::MAX..usize::MAX).saturating_add(1),
+            ByteRange::from(usize::MAX..usize::MAX)
         );
         assert_eq!(
-            ByteRange::from(..usize::max_value()).saturating_add(1),
-            ByteRange::from(..usize::max_value())
+            ByteRange::from(..usize::MAX).saturating_add(1),
+            ByteRange::from(..usize::MAX)
         );
 
         assert_eq!(
-            ByteRange::from(usize::max_value() - 5..usize::max_value()).saturating_add(1),
-            ByteRange::from(usize::max_value() - 5..usize::max_value())
+            ByteRange::from(usize::MAX - 5..usize::MAX).saturating_add(1),
+            ByteRange::from(usize::MAX - 5..usize::MAX)
         );
 
         // overflow, but something can be added to the range:
         assert_eq!(
-            ByteRange::from(usize::max_value() - 5..usize::max_value() - 3).saturating_add(4),
-            ByteRange::from(usize::max_value() - 2..usize::max_value())
+            ByteRange::from(usize::MAX - 5..usize::MAX - 3).saturating_add(4),
+            ByteRange::from(usize::MAX - 2..usize::MAX)
         );
 
         assert_eq!(
-            ByteRange::from(..usize::max_value() - 3).saturating_add(4),
-            ByteRange::from(..usize::max_value())
+            ByteRange::from(..usize::MAX - 3).saturating_add(4),
+            ByteRange::from(..usize::MAX)
         );
     }
 

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -220,6 +220,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unit_cmp)] // fucked test
     fn test_hash() {
         let mut hasher_left = std::collections::hash_map::DefaultHasher::new();
         let mut hasher_right = std::collections::hash_map::DefaultHasher::new();
@@ -251,8 +252,8 @@ mod tests {
 
     #[test]
     fn test_partial_eq() {
-        assert_eq!(Float::new(1.0).eq(&Float::new(1.0)), true);
-        assert_eq!(Float::new(1.0).eq(&Float::new(33.3)), false);
+        assert_eq!(Float::new(1.0), Float::new(1.0));
+        assert_ne!(Float::new(1.0), Float::new(33.3));
         assert_eq!(Float::new(1.1), 1.1);
     }
 
@@ -276,15 +277,15 @@ mod tests {
 
     #[test]
     #[should_panic = "float must be finite: `inf`"]
-    fn test_new_infinite() { let _ = Float::new(::core::f32::INFINITY); }
+    fn test_new_infinite() { let _ = Float::new(f32::INFINITY); }
 
     #[test]
     #[should_panic = "float must be finite: `-inf`"]
-    fn test_new_neg_infinite() { let _ = Float::new(::core::f32::NEG_INFINITY); }
+    fn test_new_neg_infinite() { let _ = Float::new(f32::NEG_INFINITY); }
 
     #[test]
     #[should_panic = "float must not be `NaN`"]
-    fn test_new_nan() { let _ = Float::new(::core::f32::NAN); }
+    fn test_new_nan() { let _ = Float::new(f32::NAN); }
 
     #[test]
     fn test_as_f32() {
@@ -304,8 +305,8 @@ mod tests {
         assert_eq!(Float::try_from(1.1_f32).unwrap(), Float::new(1.1));
         assert_eq!(Float::try_from(-1.1_f32).unwrap(), Float::new(-1.1));
 
-        assert!(Float::try_from(::core::f32::INFINITY).is_err());
-        assert!(Float::try_from(::core::f32::NAN).is_err());
-        assert!(Float::try_from(::core::f32::NEG_INFINITY).is_err());
+        assert!(Float::try_from(f32::INFINITY).is_err());
+        assert!(Float::try_from(f32::NAN).is_err());
+        assert!(Float::try_from(f32::NEG_INFINITY).is_err());
     }
 }

--- a/src/types/key_format.rs
+++ b/src/types/key_format.rs
@@ -33,7 +33,7 @@ impl FromStr for KeyFormat {
 }
 
 impl fmt::Display for KeyFormat {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", quote(&"identity")) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", quote("identity")) }
 }
 
 /// This tag requires [`ProtocolVersion::V5`].

--- a/src/types/key_format_versions.rs
+++ b/src/types/key_format_versions.rs
@@ -459,6 +459,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
+    #[allow(clippy::unit_cmp)] // fucked test
     fn test_hash() {
         let mut hasher_left = std::collections::hash_map::DefaultHasher::new();
         let mut hasher_right = std::collections::hash_map::DefaultHasher::new();
@@ -665,13 +666,13 @@ mod tests {
 
     #[test]
     fn test_is_default() {
-        assert_eq!(KeyFormatVersions::new().is_default(), true);
-        assert_eq!(KeyFormatVersions::default().is_default(), true);
+        assert!(KeyFormatVersions::new().is_default());
+        assert!(KeyFormatVersions::default().is_default());
 
-        assert_eq!(KeyFormatVersions::from([]).is_default(), true);
-        assert_eq!(KeyFormatVersions::from([1]).is_default(), true);
+        assert!(KeyFormatVersions::from([]).is_default());
+        assert!(KeyFormatVersions::from([1]).is_default());
 
-        assert_eq!(KeyFormatVersions::from([1, 2, 3]).is_default(), false);
+        assert!(!KeyFormatVersions::from([1, 2, 3]).is_default());
     }
 
     #[test]

--- a/src/types/resolution.rs
+++ b/src/types/resolution.rs
@@ -56,8 +56,8 @@ impl From<(usize, usize)> for Resolution {
     fn from(value: (usize, usize)) -> Self { Self::new(value.0, value.1) }
 }
 
-impl Into<(usize, usize)> for Resolution {
-    fn into(self) -> (usize, usize) { (self.width, self.height) }
+impl From<Resolution> for (usize, usize) {
+    fn from(val: Resolution) -> Self { (val.width, val.height) }
 }
 
 impl FromStr for Resolution {

--- a/src/types/ufloat.rs
+++ b/src/types/ufloat.rs
@@ -224,6 +224,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unit_cmp)] // fucked test
     fn test_hash() {
         let mut hasher_left = std::collections::hash_map::DefaultHasher::new();
         let mut hasher_right = std::collections::hash_map::DefaultHasher::new();
@@ -261,8 +262,8 @@ mod tests {
 
     #[test]
     fn test_partial_eq() {
-        assert_eq!(UFloat::new(1.0).eq(&UFloat::new(1.0)), true);
-        assert_eq!(UFloat::new(1.0).eq(&UFloat::new(33.3)), false);
+        assert_eq!(UFloat::new(1.0), UFloat::new(1.0));
+        assert_ne!(UFloat::new(1.0), UFloat::new(33.3));
         assert_eq!(UFloat::new(1.1), 1.1);
     }
 
@@ -276,15 +277,15 @@ mod tests {
 
     #[test]
     #[should_panic = "float must be finite: `inf`"]
-    fn test_new_infinite() { let _ = UFloat::new(::core::f32::INFINITY); }
+    fn test_new_infinite() { let _ = UFloat::new(f32::INFINITY); }
 
     #[test]
     #[should_panic = "float must be finite: `-inf`"]
-    fn test_new_neg_infinite() { let _ = UFloat::new(::core::f32::NEG_INFINITY); }
+    fn test_new_neg_infinite() { let _ = UFloat::new(f32::NEG_INFINITY); }
 
     #[test]
     #[should_panic = "float must not be `NaN`"]
-    fn test_new_nan() { let _ = UFloat::new(::core::f32::NAN); }
+    fn test_new_nan() { let _ = UFloat::new(f32::NAN); }
 
     #[test]
     fn test_as_f32() {
@@ -305,9 +306,9 @@ mod tests {
             UFloat::try_from(-1.1_f32),
             Err(Error::custom("float must be positive: `-1.1`"))
         );
-        assert!(UFloat::try_from(::core::f32::INFINITY).is_err());
-        assert!(UFloat::try_from(::core::f32::NAN).is_err());
-        assert!(UFloat::try_from(::core::f32::NEG_INFINITY).is_err());
+        assert!(UFloat::try_from(f32::INFINITY).is_err());
+        assert!(UFloat::try_from(f32::NAN).is_err());
+        assert!(UFloat::try_from(f32::NEG_INFINITY).is_err());
     }
 
     #[test]

--- a/tests/master_playlist.rs
+++ b/tests/master_playlist.rs
@@ -63,7 +63,7 @@ generate_tests! {
                     closed_captions: None,
                     stream_data: StreamData::builder()
                         .bandwidth(195023)
-                        .codecs(&["avc1.42e00a", "mp4a.40.2"])
+                        .codecs(["avc1.42e00a", "mp4a.40.2"])
                         .build()
                         .unwrap()
                 },
@@ -75,7 +75,7 @@ generate_tests! {
                     closed_captions: None,
                     stream_data: StreamData::builder()
                         .bandwidth(591680)
-                        .codecs(&["avc1.42e01e", "mp4a.40.2"])
+                        .codecs(["avc1.42e01e", "mp4a.40.2"])
                         .build()
                         .unwrap()
                 }

--- a/tests/rfc8216.rs
+++ b/tests/rfc8216.rs
@@ -213,7 +213,7 @@ generate_tests! {
                     closed_captions: None,
                     stream_data: StreamData::builder()
                         .bandwidth(65000)
-                        .codecs(&["mp4a.40.5"])
+                        .codecs(["mp4a.40.5"])
                         .build()
                         .unwrap()
                 },
@@ -279,7 +279,7 @@ generate_tests! {
                     closed_captions: None,
                     stream_data: StreamData::builder()
                         .bandwidth(65000)
-                        .codecs(&["mp4a.40.5"])
+                        .codecs(["mp4a.40.5"])
                         .build()
                         .unwrap()
                 },
@@ -344,7 +344,7 @@ generate_tests! {
                     closed_captions: None,
                     stream_data: StreamData::builder()
                         .bandwidth(1280000)
-                        .codecs(&["..."])
+                        .codecs(["..."])
                         .build()
                         .unwrap()
                 },
@@ -356,7 +356,7 @@ generate_tests! {
                     closed_captions: None,
                     stream_data: StreamData::builder()
                         .bandwidth(2560000)
-                        .codecs(&["..."])
+                        .codecs(["..."])
                         .build()
                         .unwrap()
                 },
@@ -368,7 +368,7 @@ generate_tests! {
                     closed_captions: None,
                     stream_data: StreamData::builder()
                         .bandwidth(7680000)
-                        .codecs(&["..."])
+                        .codecs(["..."])
                         .build()
                         .unwrap()
                 },
@@ -380,7 +380,7 @@ generate_tests! {
                     closed_captions: None,
                     stream_data: StreamData::builder()
                         .bandwidth(65000)
-                        .codecs(&["mp4a.40.5"])
+                        .codecs(["mp4a.40.5"])
                         .build()
                         .unwrap()
                 },
@@ -517,7 +517,7 @@ generate_tests! {
                     closed_captions: None,
                     stream_data: StreamData::builder()
                         .bandwidth(1280000)
-                        .codecs(&["..."])
+                        .codecs(["..."])
                         .video("low")
                         .build()
                         .unwrap()
@@ -530,7 +530,7 @@ generate_tests! {
                     closed_captions: None,
                     stream_data: StreamData::builder()
                         .bandwidth(2560000)
-                        .codecs(&["..."])
+                        .codecs(["..."])
                         .video("mid")
                         .build()
                         .unwrap()
@@ -543,7 +543,7 @@ generate_tests! {
                     closed_captions: None,
                     stream_data: StreamData::builder()
                         .bandwidth(7680000)
-                        .codecs(&["..."])
+                        .codecs(["..."])
                         .video("hi")
                         .build()
                         .unwrap()


### PR DESCRIPTION
I also removed the clippy::pedantic and clippy::nursery warnings as those would take ages to fix up, when I just want to get the project into a workable state to update dependencies.