### PR TITLE
Fix incorrect doc test `{.should_panic}` attribute

### DIFF
--- a/src/tags/media_segment/key.rs
+++ b/src/tags/media_segment/key.rs
@@ -117,7 +117,7 @@ impl<'a> ExtXKey<'a> {
     /// );
     /// ```
     ///
-    /// ```{.should_panic}
+    /// ```should_panic
     /// # use hls_m3u8::tags::ExtXKey;
     /// use hls_m3u8::types::DecryptionKey;
     ///

--- a/src/types/key_format_versions.rs
+++ b/src/types/key_format_versions.rs
@@ -82,7 +82,7 @@ impl KeyFormatVersions {
     ///
     /// This will panic, because it exceeded the maximum number of elements:
     ///
-    /// ```{.should_panic}
+    /// ```should_panic
     /// # use hls_m3u8::types::KeyFormatVersions;
     /// let mut versions = KeyFormatVersions::new();
     ///


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes minor documentation changes to improve the formatting of code examples in the `hls_m3u8` library. The changes ensure that the `should_panic` attribute is correctly formatted.

Documentation improvements:

* [`src/tags/media_segment/key.rs`](diffhunk://#diff-dc13b8b009c34582cd26868e87615e80867744ec7b497a0e856981dfd24829b5L120-R120): Corrected the formatting of the `should_panic` attribute in the code example.
* [`src/types/key_format_versions.rs`](diffhunk://#diff-0724c1103581691b37134d4dba6d793ad9d99ebc51dabe1820e73ddd03a6033aL85-R85): Corrected the formatting of the `should_panic` attribute in the code example.