### PR TITLE
[Breaking] Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,21 +23,27 @@ travis-ci = { repository = "sile/hls_m3u8" }
 chrono = { version = "0.4", optional = true }
 backtrace = { version = "0.3", features = ["std"], optional = true }
 
-derive_builder = "0.9"
+derive_builder = "0.20"
 hex = "0.4"
 thiserror = "1.0"
 
-derive_more = "0.99"
+derive_more = { version = "1", features = [
+    "display",
+    "as_ref",
+    "from",
+    "deref",
+    "deref_mut",
+] }
 shorthand = "0.1"
-strum = { version = "0.17", features = ["derive"] }
+strum = { version = "0.26.3", features = ["derive"] }
 
 stable-vec = { version = "0.4" }
 
 [dev-dependencies]
-pretty_assertions = "0.6"
+pretty_assertions = "1.4.0"
 version-sync = "0.9"
-automod = "0.2"
-criterion = "0.3.1"
+automod = "1.0.14"
+criterion = "0.5.1"
 
 [[bench]]
 name = "bench_main"

--- a/src/line.rs
+++ b/src/line.rs
@@ -57,7 +57,7 @@ pub(crate) enum Line<'a> {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Display)]
-#[display(fmt = "{}")]
+#[display("{_variant}")]
 pub(crate) enum Tag<'a> {
     ExtXVersion(tags::ExtXVersion),
     ExtInf(tags::ExtInf<'a>),

--- a/src/media_segment.rs
+++ b/src/media_segment.rs
@@ -170,7 +170,7 @@ impl<'a> MediaSegment<'a> {
     ///     .duration(Duration::from_secs(4))
     ///     .uri("http://www.uri.com/")
     ///     .build()?;
-    /// # Ok::<(), String>(())
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[must_use]
     #[inline]

--- a/src/tags/master_playlist/media.rs
+++ b/src/tags/master_playlist/media.rs
@@ -283,7 +283,7 @@ impl<'a> ExtXMedia<'a> {
     ///         "public.accessibility.describes-music-and-sound"
     ///     ))
     ///     .build()?;
-    /// # Ok::<(), String>(())
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[must_use]
     #[inline]

--- a/src/tags/master_playlist/session_data.rs
+++ b/src/tags/master_playlist/session_data.rs
@@ -121,7 +121,7 @@ impl<'a> ExtXSessionData<'a> {
     ///     .data(SessionData::Value("some data".into()))
     ///     .language("en")
     ///     .build()?;
-    /// # Ok::<(), String>(())
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[must_use]
     pub fn builder() -> ExtXSessionDataBuilder<'a> { ExtXSessionDataBuilder::default() }

--- a/src/tags/media_segment/date_range.rs
+++ b/src/tags/media_segment/date_range.rs
@@ -281,7 +281,7 @@ let date_range = ExtXDateRange::builder()
     .scte35_in("0xFC002F0000000000FF1")
     .end_on_next(true)
     .build()?;
-# Ok::<(), String>(())
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 "#
     )]
@@ -306,7 +306,7 @@ let date_range = ExtXDateRange::builder()
     .scte35_in("0xFC002F0000000000FF1")
     .end_on_next(true)
     .build()?;
-# Ok::<(), String>(())
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 "#
     )]

--- a/src/tags/media_segment/key.rs
+++ b/src/tags/media_segment/key.rs
@@ -33,7 +33,7 @@ impl<'a> ExtXKey<'a> {
     ///         .versions(vec![1, 2, 3, 4, 5])
     ///         .build()?,
     /// );
-    /// # Ok::<(), String>(())
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[must_use]
     #[inline]

--- a/src/types/decryption_key.rs
+++ b/src/types/decryption_key.rs
@@ -122,7 +122,7 @@ impl<'a> DecryptionKey<'a> {
     ///     .format(KeyFormat::Identity)
     ///     .versions(&[1, 2, 3, 4, 5])
     ///     .build()?;
-    /// # Ok::<(), String>(())
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[must_use]
     #[inline]

--- a/src/types/resolution.rs
+++ b/src/types/resolution.rs
@@ -10,7 +10,7 @@ use crate::Error;
 ///
 /// For example Full HD has a resolution of 1920x1080.
 #[derive(ShortHand, Ord, PartialOrd, Debug, Clone, Copy, PartialEq, Eq, Hash, Display)]
-#[display(fmt = "{}x{}", width, height)]
+#[display("{}x{}", width, height)]
 #[shorthand(enable(must_use))]
 pub struct Resolution {
     /// Horizontal pixel dimension.


### PR DESCRIPTION
Gets rid of these ancient dep versions, sadly this doesn't fully kill `syn 1` (which is my goal) due to the `shorthand` dep but I have opened an issue over there (although I'm a little concerned about it's usage, idiomatic Rust simply makes a field public instead of a getter/setter pair).