### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -95,8 +95,8 @@ impl<'a> Iterator for AttributePairs<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for AttributePairs<'a> {}
-impl<'a> FusedIterator for AttributePairs<'a> {}
+impl ExactSizeIterator for AttributePairs<'_> {}
+impl FusedIterator for AttributePairs<'_> {}
 
 #[cfg(test)]
 mod test {

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,6 +74,7 @@ enum ErrorKind {
 pub struct Error {
     inner: ErrorKind,
     #[cfg(feature = "backtrace")]
+    #[allow(dead_code)]
     backtrace: Backtrace,
 }
 

--- a/src/line.rs
+++ b/src/line.rs
@@ -36,7 +36,7 @@ impl<'a> Iterator for Lines<'a> {
     }
 }
 
-impl<'a> FusedIterator for Lines<'a> {}
+impl FusedIterator for Lines<'_> {}
 
 impl<'a> From<&'a str> for Lines<'a> {
     fn from(buffer: &'a str) -> Self {

--- a/src/master_playlist.rs
+++ b/src/master_playlist.rs
@@ -307,7 +307,7 @@ impl<'a> MasterPlaylist<'a> {
     }
 }
 
-impl<'a> RequiredVersion for MasterPlaylist<'a> {
+impl RequiredVersion for MasterPlaylist<'_> {
     fn required_version(&self) -> ProtocolVersion {
         required_version![
             self.has_independent_segments
@@ -321,7 +321,7 @@ impl<'a> RequiredVersion for MasterPlaylist<'a> {
     }
 }
 
-impl<'a> MasterPlaylistBuilder<'a> {
+impl MasterPlaylistBuilder<'_> {
     fn validate(&self) -> Result<(), String> {
         if let Some(variant_streams) = &self.variant_streams {
             self.validate_variants(variant_streams)
@@ -422,7 +422,7 @@ impl<'a> MasterPlaylistBuilder<'a> {
     }
 }
 
-impl<'a> RequiredVersion for MasterPlaylistBuilder<'a> {
+impl RequiredVersion for MasterPlaylistBuilder<'_> {
     fn required_version(&self) -> ProtocolVersion {
         // TODO: the .flatten() can be removed as soon as `recursive traits` are
         //       supported. (RequiredVersion is implemented for Option<T>, but
@@ -441,7 +441,7 @@ impl<'a> RequiredVersion for MasterPlaylistBuilder<'a> {
     }
 }
 
-impl<'a> fmt::Display for MasterPlaylist<'a> {
+impl fmt::Display for MasterPlaylist<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{}", ExtM3u)?;
 

--- a/src/media_playlist.rs
+++ b/src/media_playlist.rs
@@ -372,7 +372,7 @@ impl<'a> MediaPlaylistBuilder<'a> {
     }
 }
 
-impl<'a> RequiredVersion for MediaPlaylistBuilder<'a> {
+impl RequiredVersion for MediaPlaylistBuilder<'_> {
     fn required_version(&self) -> ProtocolVersion {
         required_version![
             self.target_duration.map(ExtXTargetDuration),
@@ -443,7 +443,7 @@ impl<'a> MediaPlaylist<'a> {
     }
 }
 
-impl<'a> RequiredVersion for MediaPlaylist<'a> {
+impl RequiredVersion for MediaPlaylist<'_> {
     fn required_version(&self) -> ProtocolVersion {
         required_version![
             ExtXTargetDuration(self.target_duration),
@@ -461,7 +461,7 @@ impl<'a> RequiredVersion for MediaPlaylist<'a> {
     }
 }
 
-impl<'a> fmt::Display for MediaPlaylist<'a> {
+impl fmt::Display for MediaPlaylist<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{}", ExtM3u)?;
 

--- a/src/media_segment.rs
+++ b/src/media_segment.rs
@@ -153,7 +153,7 @@ pub struct MediaSegment<'a> {
     uri: Cow<'a, str>,
 }
 
-impl<'a> MediaSegment<'a> {
+impl MediaSegment<'_> {
     /// Returns a builder for a [`MediaSegment`].
     ///
     /// # Example
@@ -227,7 +227,7 @@ impl<'a> MediaSegmentBuilder<'a> {
     }
 }
 
-impl<'a> fmt::Display for MediaSegment<'a> {
+impl fmt::Display for MediaSegment<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // NOTE: self.keys will be printed by the `MediaPlaylist` to prevent redundance.
 
@@ -257,7 +257,7 @@ impl<'a> fmt::Display for MediaSegment<'a> {
     }
 }
 
-impl<'a> RequiredVersion for MediaSegment<'a> {
+impl RequiredVersion for MediaSegment<'_> {
     fn required_version(&self) -> ProtocolVersion {
         required_version![
             self.keys,

--- a/src/tags/master_playlist/media.rs
+++ b/src/tags/master_playlist/media.rs
@@ -172,7 +172,7 @@ pub struct ExtXMedia<'a> {
     pub channels: Option<Channels>,
 }
 
-impl<'a> ExtXMediaBuilder<'a> {
+impl ExtXMediaBuilder<'_> {
     fn validate(&self) -> Result<(), String> {
         // A MediaType is always required!
         let media_type = self
@@ -318,14 +318,14 @@ impl<'a> ExtXMedia<'a> {
 
 /// This tag requires either `ProtocolVersion::V1` or if there is an
 /// `instream_id` it requires it's version.
-impl<'a> RequiredVersion for ExtXMedia<'a> {
+impl RequiredVersion for ExtXMedia<'_> {
     fn required_version(&self) -> ProtocolVersion {
         self.instream_id
             .map_or(ProtocolVersion::V1, |i| i.required_version())
     }
 }
 
-impl<'a> fmt::Display for ExtXMedia<'a> {
+impl fmt::Display for ExtXMedia<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Self::PREFIX)?;
         write!(f, "TYPE={}", self.media_type)?;

--- a/src/tags/master_playlist/session_data.rs
+++ b/src/tags/master_playlist/session_data.rs
@@ -28,7 +28,7 @@ pub enum SessionData<'a> {
     Uri(Cow<'a, str>),
 }
 
-impl<'a> SessionData<'a> {
+impl SessionData<'_> {
     /// Makes the struct independent of its lifetime, by taking ownership of all
     /// internal [`Cow`]s.
     ///
@@ -172,13 +172,13 @@ impl<'a> ExtXSessionData<'a> {
 }
 
 /// This tag requires [`ProtocolVersion::V1`].
-impl<'a> RequiredVersion for ExtXSessionData<'a> {
+impl RequiredVersion for ExtXSessionData<'_> {
     fn required_version(&self) -> ProtocolVersion {
         ProtocolVersion::V1
     }
 }
 
-impl<'a> fmt::Display for ExtXSessionData<'a> {
+impl fmt::Display for ExtXSessionData<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Self::PREFIX)?;
         write!(f, "DATA-ID={}", quote(&self.data_id))?;

--- a/src/tags/master_playlist/session_key.rs
+++ b/src/tags/master_playlist/session_key.rs
@@ -73,13 +73,13 @@ impl<'a> TryFrom<ExtXKey<'a>> for ExtXSessionKey<'a> {
 
 /// This tag requires the same [`ProtocolVersion`] that is returned by
 /// `DecryptionKey::required_version`.
-impl<'a> RequiredVersion for ExtXSessionKey<'a> {
+impl RequiredVersion for ExtXSessionKey<'_> {
     fn required_version(&self) -> ProtocolVersion {
         self.0.required_version()
     }
 }
 
-impl<'a> fmt::Display for ExtXSessionKey<'a> {
+impl fmt::Display for ExtXSessionKey<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}{}", Self::PREFIX, self.0)
     }

--- a/src/tags/master_playlist/variant_stream.rs
+++ b/src/tags/master_playlist/variant_stream.rs
@@ -168,7 +168,7 @@ pub enum VariantStream<'a> {
     },
 }
 
-impl<'a> VariantStream<'a> {
+impl VariantStream<'_> {
     pub(crate) const PREFIX_EXTXIFRAME: &'static str = "#EXT-X-I-FRAME-STREAM-INF:";
     pub(crate) const PREFIX_EXTXSTREAMINF: &'static str = "#EXT-X-STREAM-INF:";
 
@@ -265,7 +265,7 @@ impl<'a> VariantStream<'a> {
 }
 
 /// This tag requires [`ProtocolVersion::V1`].
-impl<'a> RequiredVersion for VariantStream<'a> {
+impl RequiredVersion for VariantStream<'_> {
     fn required_version(&self) -> ProtocolVersion {
         ProtocolVersion::V1
     }
@@ -291,7 +291,7 @@ impl<'a> RequiredVersion for VariantStream<'a> {
     }
 }
 
-impl<'a> fmt::Display for VariantStream<'a> {
+impl fmt::Display for VariantStream<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             Self::ExtXIFrame { uri, stream_data } => {

--- a/src/tags/media_segment/date_range.rs
+++ b/src/tags/media_segment/date_range.rs
@@ -352,7 +352,7 @@ let date_range = ExtXDateRange::builder()
 }
 
 /// This tag requires [`ProtocolVersion::V1`].
-impl<'a> RequiredVersion for ExtXDateRange<'a> {
+impl RequiredVersion for ExtXDateRange<'_> {
     fn required_version(&self) -> ProtocolVersion {
         ProtocolVersion::V1
     }
@@ -485,7 +485,7 @@ impl<'a> TryFrom<&'a str> for ExtXDateRange<'a> {
     }
 }
 
-impl<'a> fmt::Display for ExtXDateRange<'a> {
+impl fmt::Display for ExtXDateRange<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Self::PREFIX)?;
         write!(f, "ID={}", quote(&self.id))?;
@@ -500,7 +500,7 @@ impl<'a> fmt::Display for ExtXDateRange<'a> {
                 write!(
                     f,
                     ",START-DATE={}",
-                    quote(&value.to_rfc3339_opts(SecondsFormat::AutoSi, true))
+                    quote(value.to_rfc3339_opts(SecondsFormat::AutoSi, true))
                 )?;
             }
 
@@ -516,7 +516,7 @@ impl<'a> fmt::Display for ExtXDateRange<'a> {
                 write!(
                     f,
                     ",END-DATE={}",
-                    quote(&value.to_rfc3339_opts(SecondsFormat::AutoSi, true))
+                    quote(value.to_rfc3339_opts(SecondsFormat::AutoSi, true))
                 )?;
             }
 

--- a/src/tags/media_segment/inf.rs
+++ b/src/tags/media_segment/inf.rs
@@ -147,7 +147,7 @@ impl<'a> ExtInf<'a> {
 
 /// This tag requires [`ProtocolVersion::V1`], if the duration does not have
 /// nanoseconds, otherwise it requires [`ProtocolVersion::V3`].
-impl<'a> RequiredVersion for ExtInf<'a> {
+impl RequiredVersion for ExtInf<'_> {
     fn required_version(&self) -> ProtocolVersion {
         if self.duration.subsec_nanos() == 0 {
             ProtocolVersion::V1
@@ -157,7 +157,7 @@ impl<'a> RequiredVersion for ExtInf<'a> {
     }
 }
 
-impl<'a> fmt::Display for ExtInf<'a> {
+impl fmt::Display for ExtInf<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Self::PREFIX)?;
         write!(f, "{},", self.duration.as_secs_f64())?;
@@ -192,7 +192,7 @@ impl<'a> TryFrom<&'a str> for ExtInf<'a> {
     }
 }
 
-impl<'a> From<Duration> for ExtInf<'a> {
+impl From<Duration> for ExtInf<'_> {
     fn from(value: Duration) -> Self {
         Self::new(value)
     }

--- a/src/tags/media_segment/key.rs
+++ b/src/tags/media_segment/key.rs
@@ -194,7 +194,7 @@ impl<'a> ExtXKey<'a> {
 /// specified.
 ///
 /// Otherwise [`ProtocolVersion::V1`] is required.
-impl<'a> RequiredVersion for ExtXKey<'a> {
+impl RequiredVersion for ExtXKey<'_> {
     fn required_version(&self) -> ProtocolVersion {
         self.0
             .as_ref()
@@ -234,7 +234,7 @@ impl<'a> From<crate::tags::ExtXSessionKey<'a>> for ExtXKey<'a> {
     }
 }
 
-impl<'a> fmt::Display for ExtXKey<'a> {
+impl fmt::Display for ExtXKey<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Self::PREFIX)?;
 

--- a/src/tags/media_segment/map.rs
+++ b/src/tags/media_segment/map.rs
@@ -115,7 +115,7 @@ impl<'a> Decryptable<'a> for ExtXMap<'a> {
 ///
 /// [`ExtXIFramesOnly`]: crate::tags::ExtXIFramesOnly
 /// [`MediaPlaylist`]: crate::MediaPlaylist
-impl<'a> RequiredVersion for ExtXMap<'a> {
+impl RequiredVersion for ExtXMap<'_> {
     // this should return ProtocolVersion::V5, if it does not contain an
     // EXT-X-I-FRAMES-ONLY!
     // http://alexzambelli.com/blog/2016/05/04/understanding-hls-versions-and-client-compatibility/
@@ -128,7 +128,7 @@ impl<'a> RequiredVersion for ExtXMap<'a> {
     }
 }
 
-impl<'a> fmt::Display for ExtXMap<'a> {
+impl fmt::Display for ExtXMap<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Self::PREFIX)?;
         write!(f, "URI={}", quote(&self.uri))?;

--- a/src/tags/media_segment/program_date_time.rs
+++ b/src/tags/media_segment/program_date_time.rs
@@ -41,7 +41,7 @@ pub struct ExtXProgramDateTime<'a> {
     _p: PhantomData<&'a str>,
 }
 
-impl<'a> ExtXProgramDateTime<'a> {
+impl ExtXProgramDateTime<'_> {
     pub(crate) const PREFIX: &'static str = "#EXT-X-PROGRAM-DATE-TIME:";
 
     /// Makes a new [`ExtXProgramDateTime`] tag.
@@ -104,13 +104,13 @@ impl<'a> ExtXProgramDateTime<'a> {
 }
 
 /// This tag requires [`ProtocolVersion::V1`].
-impl<'a> RequiredVersion for ExtXProgramDateTime<'a> {
+impl RequiredVersion for ExtXProgramDateTime<'_> {
     fn required_version(&self) -> ProtocolVersion {
         ProtocolVersion::V1
     }
 }
 
-impl<'a> fmt::Display for ExtXProgramDateTime<'a> {
+impl fmt::Display for ExtXProgramDateTime<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let date_time = {
             #[cfg(feature = "chrono")]

--- a/src/tags/media_segment/program_date_time.rs
+++ b/src/tags/media_segment/program_date_time.rs
@@ -41,7 +41,7 @@ pub struct ExtXProgramDateTime<'a> {
     _p: PhantomData<&'a str>,
 }
 
-impl ExtXProgramDateTime<'_> {
+impl<'a> ExtXProgramDateTime<'a> {
     pub(crate) const PREFIX: &'static str = "#EXT-X-PROGRAM-DATE-TIME:";
 
     /// Makes a new [`ExtXProgramDateTime`] tag.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,8 +6,8 @@ use crate::types::{DecryptionKey, ProtocolVersion};
 
 mod private {
     pub trait Sealed {}
-    impl<'a> Sealed for crate::MediaSegment<'a> {}
-    impl<'a> Sealed for crate::tags::ExtXMap<'a> {}
+    impl Sealed for crate::MediaSegment<'_> {}
+    impl Sealed for crate::tags::ExtXMap<'_> {}
 }
 
 /// Signals that a type or some of the asssociated data might need to be

--- a/src/types/closed_captions.rs
+++ b/src/types/closed_captions.rs
@@ -69,7 +69,7 @@ impl<'a> ClosedCaptions<'a> {
     }
 }
 
-impl<'a, T: PartialEq<str>> PartialEq<T> for ClosedCaptions<'a> {
+impl<T: PartialEq<str>> PartialEq<T> for ClosedCaptions<'_> {
     fn eq(&self, other: &T) -> bool {
         match &self {
             Self::GroupId(value) => other.eq(value),
@@ -78,7 +78,7 @@ impl<'a, T: PartialEq<str>> PartialEq<T> for ClosedCaptions<'a> {
     }
 }
 
-impl<'a> fmt::Display for ClosedCaptions<'a> {
+impl fmt::Display for ClosedCaptions<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             Self::GroupId(value) => write!(f, "{}", quote(value)),

--- a/src/types/codecs.rs
+++ b/src/types/codecs.rs
@@ -30,7 +30,7 @@ pub struct Codecs<'a> {
     list: Vec<Cow<'a, str>>,
 }
 
-impl<'a> Codecs<'a> {
+impl Codecs<'_> {
     /// Makes a new (empty) [`Codecs`] struct.
     ///
     /// # Example
@@ -121,7 +121,7 @@ implement_from!(
     0x20
 );
 
-impl<'a> fmt::Display for Codecs<'a> {
+impl fmt::Display for Codecs<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(codec) = self.list.first() {
             write!(f, "{}", codec)?;

--- a/src/types/decryption_key.rs
+++ b/src/types/decryption_key.rs
@@ -153,7 +153,7 @@ impl<'a> DecryptionKey<'a> {
 /// specified.
 ///
 /// Otherwise [`ProtocolVersion::V1`] is required.
-impl<'a> RequiredVersion for DecryptionKey<'a> {
+impl RequiredVersion for DecryptionKey<'_> {
     fn required_version(&self) -> ProtocolVersion {
         if self.format.is_some() || self.versions.is_some() {
             ProtocolVersion::V5
@@ -210,7 +210,7 @@ impl<'a> TryFrom<&'a str> for DecryptionKey<'a> {
     }
 }
 
-impl<'a> fmt::Display for DecryptionKey<'a> {
+impl fmt::Display for DecryptionKey<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "METHOD={},URI={}", self.method, quote(&self.uri))?;
 
@@ -232,7 +232,7 @@ impl<'a> fmt::Display for DecryptionKey<'a> {
     }
 }
 
-impl<'a> DecryptionKeyBuilder<'a> {
+impl DecryptionKeyBuilder<'_> {
     fn validate(&self) -> Result<(), String> {
         // a decryption key must contain a uri and a method
         if self.method.is_none() {

--- a/src/types/stream_data.rs
+++ b/src/types/stream_data.rs
@@ -277,7 +277,7 @@ impl<'a> StreamData<'a> {
     }
 }
 
-impl<'a> fmt::Display for StreamData<'a> {
+impl fmt::Display for StreamData<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "BANDWIDTH={}", self.bandwidth)?;
 
@@ -355,7 +355,7 @@ impl<'a> TryFrom<&'a str> for StreamData<'a> {
 }
 
 /// This struct requires [`ProtocolVersion::V1`].
-impl<'a> RequiredVersion for StreamData<'a> {
+impl RequiredVersion for StreamData<'_> {
     fn required_version(&self) -> ProtocolVersion {
         ProtocolVersion::V1
     }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -18,7 +18,7 @@ pub enum Value<'a> {
     Float(Float),
 }
 
-impl<'a> Value<'a> {
+impl Value<'_> {
     /// Makes the struct independent of its lifetime, by taking ownership of all
     /// internal [`Cow`]s.
     ///
@@ -35,7 +35,7 @@ impl<'a> Value<'a> {
     }
 }
 
-impl<'a> fmt::Display for Value<'a> {
+impl fmt::Display for Value<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             Self::String(value) => write!(f, "{}", quote(value)),


### PR DESCRIPTION
Copilot Summary 
---

This pull request includes several changes to the codebase, primarily focusing on replacing lifetime annotations with underscores to simplify the code. Additionally, there are minor improvements to the `Error` struct and the `ExtXDateRange` tag. The most important changes are summarized below:

### Lifetime Annotation Simplifications:

* [`src/attribute.rs`](diffhunk://#diff-42f6ab42aad4bae09080fcd0b40653449a511aafe8e103dfe7586adcec932811L98-R99): Updated implementations of `ExactSizeIterator` and `FusedIterator` for `AttributePairs` to use underscores instead of explicit lifetimes.
* [`src/line.rs`](diffhunk://#diff-2049bbb4f0390b56fbe46d628de28da936c58f959e81625ebe611809c023157aL39-R39): Updated implementation of `FusedIterator` for `Lines` to use underscores instead of explicit lifetimes.
* [`src/master_playlist.rs`](diffhunk://#diff-6623c0d2c524dcdd421c287d07a23108e7aee9f10bd55036d6ae7b6d4cb7ae36L310-R310): Updated several implementations (`RequiredVersion`, `MasterPlaylistBuilder`, `fmt::Display`) for `MasterPlaylist` and `MasterPlaylistBuilder` to use underscores instead of explicit lifetimes. [[1]](diffhunk://#diff-6623c0d2c524dcdd421c287d07a23108e7aee9f10bd55036d6ae7b6d4cb7ae36L310-R310) [[2]](diffhunk://#diff-6623c0d2c524dcdd421c287d07a23108e7aee9f10bd55036d6ae7b6d4cb7ae36L324-R324) [[3]](diffhunk://#diff-6623c0d2c524dcdd421c287d07a23108e7aee9f10bd55036d6ae7b6d4cb7ae36L425-R425) [[4]](diffhunk://#diff-6623c0d2c524dcdd421c287d07a23108e7aee9f10bd55036d6ae7b6d4cb7ae36L444-R444)
* [`src/media_playlist.rs`](diffhunk://#diff-e11959119b7f2d60fb18a29b9bed634d06f88835efeb0ffcbaf7ce03156df150L375-R375): Updated implementations of `RequiredVersion` and `fmt::Display` for `MediaPlaylist` and `MediaPlaylistBuilder` to use underscores instead of explicit lifetimes. [[1]](diffhunk://#diff-e11959119b7f2d60fb18a29b9bed634d06f88835efeb0ffcbaf7ce03156df150L375-R375) [[2]](diffhunk://#diff-e11959119b7f2d60fb18a29b9bed634d06f88835efeb0ffcbaf7ce03156df150L446-R446) [[3]](diffhunk://#diff-e11959119b7f2d60fb18a29b9bed634d06f88835efeb0ffcbaf7ce03156df150L464-R464)

### Minor Code Improvements:

* [`src/error.rs`](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eR77): Added `#[allow(dead_code)]` to the `backtrace` field in the `Error` struct to suppress warnings.
* [`src/tags/media_segment/date_range.rs`](diffhunk://#diff-21368b56a0e66b369316d17e3af8dd86b40ca49ee96efee448f666190f957656L503-R503): Removed unnecessary reference in `quote` function calls within the `fmt::Display` implementation for `ExtXDateRange`. [[1]](diffhunk://#diff-21368b56a0e66b369316d17e3af8dd86b40ca49ee96efee448f666190f957656L503-R503) [[2]](diffhunk://#diff-21368b56a0e66b369316d17e3af8dd86b40ca49ee96efee448f666190f957656L519-R519)