### PR TITLE
Add support for dolby atmos

### DIFF
--- a/src/tags/master_playlist/media.rs
+++ b/src/tags/master_playlist/media.rs
@@ -675,7 +675,7 @@ mod test {
                 .name("English")
                 .is_autoselect(true)
                 .is_default(true)
-                .channels(Channels::new(2, false))
+                .channels(Channels::new(2))
                 .build()
                 .unwrap(),
             concat!(

--- a/src/tags/master_playlist/media.rs
+++ b/src/tags/master_playlist/media.rs
@@ -675,7 +675,7 @@ mod test {
                 .name("English")
                 .is_autoselect(true)
                 .is_default(true)
-                .channels(Channels::new(2))
+                .channels(Channels::new(2, false))
                 .build()
                 .unwrap(),
             concat!(

--- a/src/types/channels.rs
+++ b/src/types/channels.rs
@@ -59,11 +59,6 @@ impl Channels {
 impl FromStr for Channels {
     type Err = Error;
 
-    /// Makes a new [`Channels`] struct from a str.
-    ///
-    /// Has significant extra logic to account for the addition of Enhanced AC-3 audio with JOC, which
-    /// allows for strings like "16/JOC".
-    /// #[inline]
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         // Lots of extra logic to deal with Dolby Atmos
         let split: Vec<&str> = input.splitn(2, "/").collect::<Vec<&str>>();

--- a/src/types/channels.rs
+++ b/src/types/channels.rs
@@ -21,7 +21,7 @@ pub struct Channels {
     ///
     /// ```
     /// # use hls_m3u8::types::Channels;
-    /// let mut channels = Channels::new(6, false);
+    /// let mut channels = Channels::new(6);
     /// # assert_eq!(channels.number(), 6);
     /// assert_eq!(channels.has_joc_content(), false);
     ///
@@ -41,16 +41,17 @@ impl Channels {
     ///
     /// ```
     /// # use hls_m3u8::types::Channels;
-    /// let channels = Channels::new(6, false);
+    /// let channels = Channels::new(6);
     ///
     /// println!("CHANNELS=\"{}\"", channels);
     /// # assert_eq!(format!("CHANNELS=\"{}\"", channels), "CHANNELS=\"6\"".to_string());
     /// ```
+    /// #[inline]
     #[must_use]
-    pub const fn new(number: u64, has_joc_content: bool) -> Self {
+    pub const fn new(number: u64) -> Self {
         Self {
             number,
-            has_joc_content,
+            has_joc_content: false,
         }
     }
 }
@@ -65,28 +66,30 @@ impl FromStr for Channels {
     /// #[inline]
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         // Lots of extra logic to deal with Dolby Atmos
-        let split: Vec<&str> = input.split("/").collect::<Vec<&str>>();
+        let split: Vec<&str> = input.splitn(2, "/").collect::<Vec<&str>>();
         let num_str = split
             .get(0)
             .ok_or_else(|| Error::missing_value("Missing Channel value"))?;
 
-        let joc_coding = match split.get(1) {
-            Some(&"JOC") => true,
+        let mut new_channels =
+            Self::new(num_str.parse().map_err(|e| Error::parse_int(num_str, e))?);
+
+        match split.get(1) {
+            Some(&"JOC") => new_channels.set_has_joc_content(true),
             Some(_) => return Err(Error::invalid_input()),
-            None => false,
+            None => &mut new_channels,
         };
 
-        Ok(Self::new(
-            num_str.parse().map_err(|e| Error::parse_int(num_str, e))?,
-            joc_coding,
-        ))
+        Ok(new_channels)
     }
 }
 
 impl fmt::Display for Channels {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.number)?;
-
+        match self.has_joc_content {
+            true => write!(f, "{}/JOC", self.number)?,
+            false => write!(f, "{}", self.number)?,
+        }
         Ok(())
     }
 }
@@ -98,14 +101,16 @@ mod tests {
 
     #[test]
     fn test_display() {
-        assert_eq!(Channels::new(6, false).to_string(), "6".to_string());
+        assert_eq!(Channels::new(6).to_string(), "6".to_string());
 
-        assert_eq!(Channels::new(7, true).to_string(), "7".to_string());
+        let test_channel = Channels::from_str("7/JOC").unwrap();
+
+        assert_eq!(test_channel.to_string(), "7/JOC".to_string());
     }
 
     #[test]
     fn test_parser() {
-        assert_eq!(Channels::new(6, false), Channels::from_str("6").unwrap());
+        assert_eq!(Channels::new(6), Channels::from_str("6").unwrap());
 
         assert!(Channels::from_str("garbage").is_err());
         assert!(Channels::from_str("").is_err());
@@ -113,10 +118,12 @@ mod tests {
 
     #[test]
     fn test_parser_dolby_atmos() {
-        assert_eq!(
-            Channels::new(16, true),
-            Channels::from_str("16/JOC").unwrap()
-        );
+        let mut test_channels = Channels::new(16);
+        test_channels.set_has_joc_content(true);
+
+        assert_eq!(test_channels, Channels::from_str("16/JOC").unwrap());
+
         assert!(Channels::from_str("16/JOKE").is_err());
+        assert!(Channels::from_str("16/JOC/4").is_err());
     }
 }


### PR DESCRIPTION
Per [this](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices-appendixes) documentation, the Channels attribute is allowed to have an optional "/JOC" appended to the end of the numeric value to represent the presence of JOC content. This PR modifies the channel parsing to allow for that. 