### PR TITLE
Modernize codebase: edition 2024, expect attributes, and CI refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,11 @@ jobs:
         toolchain: [stable, beta, nightly]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - run: rustup update ${{ matrix.toolchain }}
+      - run: rustup default ${{ matrix.toolchain }}
       - run: cargo check --all
+      - run: cargo check --all --all-features
 
   test:
     name: Test Suite
@@ -23,19 +25,24 @@ jobs:
         toolchain: [stable, beta, nightly]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - run: rustup update ${{ matrix.toolchain }}
+      - run: rustup default ${{ matrix.toolchain }}
       - run: cargo test --all
+      - run: cargo test --all --all-features
 
   lints:
     name: Lints
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [stable, beta, nightly]
+        toolchain: [stable]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - run: rustup update ${{ matrix.toolchain }}
+      - run: rustup default ${{ matrix.toolchain }}
+      - run: rustup component add rustfmt clippy
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all -- -D warnings
+      - run: cargo clippy --all --all-features -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }}
       - run: rustup default ${{ matrix.toolchain }}
       - run: cargo check --all
-      - run: cargo check --all --all-features
 
   test:
     name: Test Suite
@@ -29,7 +28,6 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }}
       - run: rustup default ${{ matrix.toolchain }}
       - run: cargo test --all
-      - run: cargo test --all --all-features
 
   lints:
     name: Lints
@@ -45,4 +43,3 @@ jobs:
       - run: rustup component add rustfmt clippy
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all -- -D warnings
-      - run: cargo clippy --all --all-features -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hls_m3u8"
-version = "0.6.0" # remember to update html_root_url
+version = "0.6.0"
 authors = ["Takeru Ohta <phjgt308@gmail.com>", "Luro02 <24826124+Luro02@users.noreply.github.com>"]
 description = "HLS m3u8 parser/generator"
 homepage = "https://github.com/sile/hls_m3u8"
@@ -8,7 +8,8 @@ repository = "https://github.com/sile/hls_m3u8"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["hls", "m3u8"]
-edition = "2018"
+edition = "2024"
+rust-version = "1.88"
 categories = ["parser-implementations"]
 
 [features]
@@ -37,7 +38,6 @@ stable-vec = { version = "0.4" }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
-version-sync = "0.9"
 automod = "1.0.14"
 criterion = "0.5.1"
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 hls_m3u8
-=========
+========
 
-[![Crates.io: hls_m3u8](https://img.shields.io/crates/v/hls_m3u8.svg)](https://crates.io/crates/hls_m3u8)
+[![hls_m3u8](https://img.shields.io/crates/v/hls_m3u8.svg)](https://crates.io/crates/hls_m3u8)
 [![Documentation](https://docs.rs/hls_m3u8/badge.svg)](https://docs.rs/hls_m3u8)
 [![Actions Status](https://github.com/sile/hls_m3u8/workflows/CI/badge.svg)](https://github.com/sile/hls_m3u8/actions)
 ![License](https://img.shields.io/crates/l/hls_m3u8)
 
 [HLS] m3u8 parser/generator.
 
-[Documentation](https://docs.rs/hls_m3u8)
-
 [HLS]: https://tools.ietf.org/html/rfc8216
 
+
 Examples
----------
+--------
 
 ```rust
 use hls_m3u8::MediaPlaylist;
@@ -32,18 +31,20 @@ http://media.example.com/third.ts
 assert!(m3u8.parse::<MediaPlaylist>().is_ok());
 ```
 
-## License
+
+License
+-------
 
 Licensed under either of
 
-- Apache License, Version 2.0
-  ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license
-  ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 
-## Contribution
+
+Contribution
+------------
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be

--- a/benches/benchmarks/media_playlist.rs
+++ b/benches/benchmarks/media_playlist.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 use std::str::FromStr;
 use std::time::Duration;
 
-use criterion::{black_box, criterion_group, Criterion, Throughput};
+use criterion::{Criterion, Throughput, black_box, criterion_group};
 
 use hls_m3u8::tags::{ExtXDateRange, ExtXProgramDateTime};
 use hls_m3u8::types::Value;

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,7 +74,7 @@ enum ErrorKind {
 pub struct Error {
     inner: ErrorKind,
     #[cfg(feature = "backtrace")]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     backtrace: Backtrace,
 }
 
@@ -92,7 +92,7 @@ impl fmt::Display for Error {
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 impl Error {
     fn new(inner: ErrorKind) -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,12 @@
-#![doc(html_root_url = "https://docs.rs/hls_m3u8/0.6.0")]
 #![forbid(unsafe_code)]
-#![warn(rust_2018_idioms)]
-#![warn(clippy::cargo, clippy::inline_always)]
 #![allow(
-    clippy::non_ascii_literal,
-    clippy::redundant_pub_crate,
-    clippy::multiple_crate_versions,
+    clippy::collapsible_if,
+    clippy::infallible_try_from,
+    clippy::large_enum_variant,
     clippy::module_name_repetitions,
     clippy::default_trait_access,
-    clippy::unnecessary_operation // temporary until derive-builder uses #[allow(clippy::all)]
+    clippy::unnecessary_operation
 )]
-#![warn(
-    clippy::clone_on_ref_ptr,
-    clippy::decimal_literal_representation,
-    clippy::get_unwrap,
-    clippy::unneeded_field_pattern,
-    clippy::wrong_self_convention
-)]
-#![cfg_attr(not(test), warn(clippy::expect_used))]
-// those should not be present in production code:
 #![deny(
     clippy::print_stdout,
     clippy::todo,
@@ -39,7 +27,6 @@
 //!
 //! ```
 //! use hls_m3u8::MediaPlaylist;
-//! use std::convert::TryFrom;
 //!
 //! let m3u8 = MediaPlaylist::try_from(concat!(
 //!     "#EXTM3U\n",
@@ -57,18 +44,14 @@
 //! assert!(m3u8.is_ok());
 //! ```
 //!
-//! ## Crate Feature Flags
+//! # Crate Feature Flags
 //!
 //! The following crate feature flags are available:
 //!
-//! - [`backtrace`] (optional)
-//!   - Enables the backtrace feature for the `Error` type.
-//!   - This feature depends on the following dependencies:
-//!     - [`backtrace`]
-//! - [`chrono`] (optional)
+//! - `backtrace` (optional)
+//!   - Enables the backtrace feature for the [`Error`] type.
+//! - `chrono` (optional)
 //!   - Enables parsing dates and verifying them.
-//!   - This feature depends on the following dependencies:
-//!     - [`chrono`]
 //!   - The following things will change:
 //!     - [`ExtXProgramDateTime::date_time`] will change from [`String`] to
 //!       `DateTime<FixedOffset>`
@@ -77,20 +60,12 @@
 //!     - [`ExtXDateRange::end_date`] will change from [`String`] to
 //!       `DateTime<FixedOffset>`
 //!
-//! They are configured in your `Cargo.toml` and can be enabled like this
-//!
-//! ```toml
-//! hls_m3u8 = { version = "0.3", features = ["chrono", "backtrace"] }
-//! ```
-//!
 //! [`ExtXProgramDateTime::date_time`]:
 //! crate::tags::ExtXProgramDateTime::date_time
 //! [`ExtXDateRange::start_date`]:
 //! crate::tags::ExtXDateRange::start_date
 //! [`ExtXDateRange::end_date`]:
 //! crate::tags::ExtXDateRange::end_date
-//! [`chrono`]: https://github.com/chronotope/chrono
-//! [`backtrace`]: https://github.com/rust-lang/backtrace-rs
 //! [HLS]: https://tools.ietf.org/html/rfc8216
 
 pub use error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
 #![forbid(unsafe_code)]
-#![allow(
+#![expect(
     clippy::collapsible_if,
     clippy::infallible_try_from,
     clippy::large_enum_variant,
     clippy::module_name_repetitions,
-    clippy::default_trait_access,
     clippy::unnecessary_operation
 )]
 #![deny(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,13 +6,6 @@
     clippy::module_name_repetitions,
     clippy::unnecessary_operation
 )]
-#![deny(
-    clippy::print_stdout,
-    clippy::todo,
-    clippy::unimplemented,
-    clippy::dbg_macro,
-    clippy::use_debug
-)]
 #![warn(
     missing_docs,
     missing_copy_implementations,

--- a/src/line.rs
+++ b/src/line.rs
@@ -55,7 +55,6 @@ pub(crate) enum Line<'a> {
     Uri(&'a str),
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Display)]
 #[display("{_variant}")]
 pub(crate) enum Tag<'a> {

--- a/src/line.rs
+++ b/src/line.rs
@@ -3,9 +3,9 @@ use core::iter::FusedIterator;
 
 use derive_more::Display;
 
+use crate::Error;
 use crate::tags;
 use crate::types::PlaylistType;
-use crate::Error;
 
 #[derive(Debug, Clone)]
 pub(crate) struct Lines<'a> {

--- a/src/master_playlist.rs
+++ b/src/master_playlist.rs
@@ -11,7 +11,7 @@ use crate::tags::{
     ExtXVersion, VariantStream,
 };
 use crate::types::{ClosedCaptions, MediaType, ProtocolVersion};
-use crate::utils::{tag, BoolExt};
+use crate::utils::{BoolExt, tag};
 use crate::{Error, RequiredVersion};
 
 /// The master playlist describes all of the available variants for your

--- a/src/master_playlist.rs
+++ b/src/master_playlist.rs
@@ -277,7 +277,7 @@ impl<'a> MasterPlaylist<'a> {
     ///
     /// This is a relatively expensive operation.
     #[must_use]
-    #[allow(clippy::redundant_closure_for_method_calls)]
+    #[expect(clippy::redundant_closure_for_method_calls)]
     pub fn into_owned(self) -> MasterPlaylist<'static> {
         MasterPlaylist {
             has_independent_segments: self.has_independent_segments,

--- a/src/media_playlist.rs
+++ b/src/media_playlist.rs
@@ -18,7 +18,7 @@ use crate::tags::{
 use crate::types::{
     DecryptionKey, EncryptionMethod, InitializationVector, KeyFormat, PlaylistType, ProtocolVersion,
 };
-use crate::utils::{tag, BoolExt};
+use crate::utils::{BoolExt, tag};
 use crate::{Error, RequiredVersion};
 
 /// Media playlist.
@@ -663,13 +663,17 @@ fn parse_media_playlist<'a>(
                         // this tag must appear before the first MediaSegment in the playlist
                         // https://tools.ietf.org/html/rfc8216#section-4.3.3.3
                         if !segments.is_empty() {
-                            return Err(Error::custom("discontinuity sequence tag must appear before the first media segment in the playlist"));
+                            return Err(Error::custom(
+                                "discontinuity sequence tag must appear before the first media segment in the playlist",
+                            ));
                         }
 
                         // this tag must appear before any ExtXDiscontinuity tag
                         // https://tools.ietf.org/html/rfc8216#section-4.3.3.3
                         if has_discontinuity_tag {
-                            return Err(Error::custom("discontinuity sequence tag must appear before any `ExtXDiscontinuity` tag"));
+                            return Err(Error::custom(
+                                "discontinuity sequence tag must appear before any `ExtXDiscontinuity` tag",
+                            ));
                         }
 
                         builder.discontinuity_sequence(t.0);
@@ -764,10 +768,12 @@ mod tests {
         assert!(MediaPlaylist::try_from(playlist).is_err());
 
         // Error (allowable segment duration = 9)
-        assert!(MediaPlaylist::builder()
-            .allowable_excess_duration(Duration::from_secs(1))
-            .parse(playlist)
-            .is_err());
+        assert!(
+            MediaPlaylist::builder()
+                .allowable_excess_duration(Duration::from_secs(1))
+                .parse(playlist)
+                .is_err()
+        );
 
         // Ok (allowable segment duration = 10)
         assert_eq!(

--- a/src/media_segment.rs
+++ b/src/media_segment.rs
@@ -185,7 +185,7 @@ impl MediaSegment<'_> {
     ///
     /// This is a relatively expensive operation.
     #[must_use]
-    #[allow(clippy::redundant_closure_for_method_calls)]
+    #[expect(clippy::redundant_closure_for_method_calls)]
     pub fn into_owned(self) -> MediaSegment<'static> {
         MediaSegment {
             number: self.number,

--- a/src/tags/master_playlist/media.rs
+++ b/src/tags/master_playlist/media.rs
@@ -750,10 +750,10 @@ mod test {
         assert!(ExtXMedia::try_from("").is_err());
         assert!(ExtXMedia::try_from("garbage").is_err());
 
-        assert!(ExtXMedia::try_from(
-            "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,URI=\"http://www.example.com\""
-        )
-        .is_err());
+        assert!(
+            ExtXMedia::try_from("#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,URI=\"http://www.example.com\"")
+                .is_err()
+        );
         assert!(ExtXMedia::try_from("#EXT-X-MEDIA:TYPE=AUDIO,INSTREAM-ID=CC1").is_err());
 
         assert!(ExtXMedia::try_from("#EXT-X-MEDIA:TYPE=AUDIO,DEFAULT=YES,AUTOSELECT=NO").is_err());

--- a/src/tags/master_playlist/variant_stream.rs
+++ b/src/tags/master_playlist/variant_stream.rs
@@ -3,12 +3,12 @@ use core::fmt;
 use core::ops::Deref;
 use std::borrow::Cow;
 
+use crate::Error;
 use crate::attribute::AttributePairs;
 use crate::tags::ExtXMedia;
 use crate::traits::RequiredVersion;
 use crate::types::{ClosedCaptions, MediaType, ProtocolVersion, StreamData, UFloat};
 use crate::utils::{quote, tag, unquote};
-use crate::Error;
 
 /// A server may offer multiple [`MediaPlaylist`] files to provide different
 /// encodings of the same presentation.
@@ -443,34 +443,40 @@ mod tests {
                 .unwrap(),
         };
 
-        assert!(variant_stream.is_associated(
-            &ExtXMedia::builder()
-                .media_type(MediaType::Audio)
-                .group_id("ag1")
-                .name("audio example")
-                .build()
-                .unwrap(),
-        ));
+        assert!(
+            variant_stream.is_associated(
+                &ExtXMedia::builder()
+                    .media_type(MediaType::Audio)
+                    .group_id("ag1")
+                    .name("audio example")
+                    .build()
+                    .unwrap(),
+            )
+        );
 
-        assert!(variant_stream.is_associated(
-            &ExtXMedia::builder()
-                .media_type(MediaType::Subtitles)
-                .uri("https://www.example.com/sg1.ssa")
-                .group_id("sg1")
-                .name("subtitle example")
-                .build()
-                .unwrap(),
-        ));
+        assert!(
+            variant_stream.is_associated(
+                &ExtXMedia::builder()
+                    .media_type(MediaType::Subtitles)
+                    .uri("https://www.example.com/sg1.ssa")
+                    .group_id("sg1")
+                    .name("subtitle example")
+                    .build()
+                    .unwrap(),
+            )
+        );
 
-        assert!(variant_stream.is_associated(
-            &ExtXMedia::builder()
-                .media_type(MediaType::ClosedCaptions)
-                .group_id("cc1")
-                .name("closed captions example")
-                .instream_id(InStreamId::Cc1)
-                .build()
-                .unwrap(),
-        ));
+        assert!(
+            variant_stream.is_associated(
+                &ExtXMedia::builder()
+                    .media_type(MediaType::ClosedCaptions)
+                    .group_id("cc1")
+                    .name("closed captions example")
+                    .instream_id(InStreamId::Cc1)
+                    .build()
+                    .unwrap(),
+            )
+        );
 
         if let VariantStream::ExtXStreamInf {
             closed_captions, ..
@@ -479,23 +485,27 @@ mod tests {
             *closed_captions = Some(ClosedCaptions::None);
         }
 
-        assert!(variant_stream.is_associated(
-            &ExtXMedia::builder()
-                .media_type(MediaType::ClosedCaptions)
-                .group_id("NONE")
-                .name("closed captions example")
-                .instream_id(InStreamId::Cc1)
-                .build()
-                .unwrap(),
-        ));
+        assert!(
+            variant_stream.is_associated(
+                &ExtXMedia::builder()
+                    .media_type(MediaType::ClosedCaptions)
+                    .group_id("NONE")
+                    .name("closed captions example")
+                    .instream_id(InStreamId::Cc1)
+                    .build()
+                    .unwrap(),
+            )
+        );
 
-        assert!(variant_stream.is_associated(
-            &ExtXMedia::builder()
-                .media_type(MediaType::Video)
-                .group_id("vg1")
-                .name("video example")
-                .build()
-                .unwrap(),
-        ));
+        assert!(
+            variant_stream.is_associated(
+                &ExtXMedia::builder()
+                    .media_type(MediaType::Video)
+                    .group_id("vg1")
+                    .name("video example")
+                    .build()
+                    .unwrap(),
+            )
+        );
     }
 }

--- a/src/tags/media_segment/byte_range.rs
+++ b/src/tags/media_segment/byte_range.rs
@@ -145,7 +145,7 @@ impl RequiredVersion for ExtXByteRange {
     }
 }
 
-#[allow(clippy::from_over_into)] // Some magic `From` blanket impl is going on that means this can't be done.
+#[expect(clippy::from_over_into)] // Some magic `From` blanket impl is going on that means this can't be done.
 impl Into<ByteRange> for ExtXByteRange {
     fn into(self) -> ByteRange {
         self.0

--- a/src/tags/media_segment/program_date_time.rs
+++ b/src/tags/media_segment/program_date_time.rs
@@ -41,7 +41,6 @@ pub struct ExtXProgramDateTime<'a> {
     _p: PhantomData<&'a str>,
 }
 
-#[allow(clippy::needless_lifetimes)]
 impl<'a> ExtXProgramDateTime<'a> {
     pub(crate) const PREFIX: &'static str = "#EXT-X-PROGRAM-DATE-TIME:";
 

--- a/src/types/byte_range.rs
+++ b/src/types/byte_range.rs
@@ -291,10 +291,61 @@ impl AddAssign<usize> for ByteRange {
     }
 }
 
+impl From<Range<usize>> for ByteRange {
+    fn from(range: Range<usize>) -> Self {
+        if range.start > range.end {
+            panic!(
+                "the range start ({}) must be smaller than the end ({})",
+                range.start, range.end
+            );
+        }
+
+        Self {
+            start: Some(range.start),
+            end: range.end,
+        }
+    }
+}
+
+impl From<RangeInclusive<usize>> for ByteRange {
+    fn from(range: RangeInclusive<usize>) -> Self {
+        let (start, end) = range.into_inner();
+
+        if start > end {
+            panic!(
+                "the range start ({}) must be smaller than the end ({}+1)",
+                start, end
+            );
+        }
+
+        Self {
+            start: Some(start),
+            end: end.saturating_add(1),
+        }
+    }
+}
+
+impl From<RangeTo<usize>> for ByteRange {
+    fn from(range: RangeTo<usize>) -> Self {
+        Self {
+            start: None,
+            end: range.end,
+        }
+    }
+}
+
+impl From<RangeToInclusive<usize>> for ByteRange {
+    fn from(range: RangeToInclusive<usize>) -> Self {
+        Self {
+            start: None,
+            end: range.end.saturating_add(1),
+        }
+    }
+}
+
 macro_rules! impl_from_ranges {
     ( $( $type:tt ),* ) => {
         $(
-            #[allow(trivial_numeric_casts, clippy::fallible_impl_from)]
             impl From<Range<$type>> for ByteRange {
                 fn from(range: Range<$type>) -> Self {
                     if range.start > range.end {
@@ -311,7 +362,6 @@ macro_rules! impl_from_ranges {
                 }
             }
 
-            #[allow(trivial_numeric_casts, clippy::fallible_impl_from)]
             impl From<RangeInclusive<$type>> for ByteRange {
                 fn from(range: RangeInclusive<$type>) -> Self {
                     let (start, end) = range.into_inner();
@@ -330,7 +380,6 @@ macro_rules! impl_from_ranges {
                 }
             }
 
-            #[allow(trivial_numeric_casts, clippy::fallible_impl_from)]
             impl From<RangeTo<$type>> for ByteRange {
                 fn from(range: RangeTo<$type>) -> Self {
                     Self {
@@ -340,7 +389,6 @@ macro_rules! impl_from_ranges {
                 }
             }
 
-            #[allow(trivial_numeric_casts, clippy::fallible_impl_from)]
             impl From<RangeToInclusive<$type>> for ByteRange {
                 fn from(range: RangeToInclusive<$type>) -> Self {
                     Self {
@@ -355,7 +403,7 @@ macro_rules! impl_from_ranges {
 
 // TODO: replace with generics as soon as overlapping trait implementations are
 // stable (`Into<i64> for usize` is reserved for upstream crates ._.)
-impl_from_ranges![u64, u32, u16, u8, usize, i32];
+impl_from_ranges![u64, u32, u16, u8, i32];
 
 impl RangeBounds<usize> for ByteRange {
     fn start_bound(&self) -> Bound<&usize> {
@@ -452,14 +500,14 @@ mod tests {
 
     #[test]
     #[should_panic = "the range start (6) must be smaller than the end (0)"]
-    #[allow(clippy::reversed_empty_ranges)]
+    #[expect(clippy::reversed_empty_ranges)]
     fn test_from_range_panic() {
         let _ = ByteRange::from(6..0);
     }
 
     #[test]
     #[should_panic = "the range start (6) must be smaller than the end (0+1)"]
-    #[allow(clippy::reversed_empty_ranges)]
+    #[expect(clippy::reversed_empty_ranges)]
     fn test_from_range_inclusive_panic() {
         let _ = ByteRange::from(6..=0);
     }
@@ -529,7 +577,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::identity_op)]
+    #[expect(clippy::identity_op)]
     fn test_add() {
         // normal addition
         assert_eq!(ByteRange::from(5..10) + 5, ByteRange::from(10..15));
@@ -547,7 +595,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::identity_op)]
+    #[expect(clippy::identity_op)]
     fn test_sub() {
         // normal subtraction
         assert_eq!(ByteRange::from(5..10) - 4, ByteRange::from(1..6));

--- a/src/types/codecs.rs
+++ b/src/types/codecs.rs
@@ -74,52 +74,21 @@ where
     }
 }
 
-// TODO: this should be implemented with const generics in the future!
-macro_rules! implement_from {
-    ($($size:expr),*) => {
-        $(
-            #[allow(clippy::reversed_empty_ranges)]
-            impl<'a> From<[&'a str; $size]> for Codecs<'a> {
-                fn from(value: [&'a str; $size]) -> Self {
-                    Self {
-                        list: {
-                            let mut result = Vec::with_capacity($size);
-
-                            for i in 0..$size {
-                                result.push(Cow::Borrowed(value[i]))
-                            }
-
-                            result
-                        },
-                    }
-                }
-            }
-
-            #[allow(clippy::reversed_empty_ranges)]
-            impl<'a> From<&[&'a str; $size]> for Codecs<'a> {
-                fn from(value: &[&'a str; $size]) -> Self {
-                    Self {
-                        list: {
-                            let mut result = Vec::with_capacity($size);
-
-                            for i in 0..$size {
-                                result.push(Cow::Borrowed(value[i]))
-                            }
-
-                            result
-                        },
-                    }
-                }
-            }
-        )*
-    };
+impl<'a, const N: usize> From<[&'a str; N]> for Codecs<'a> {
+    fn from(value: [&'a str; N]) -> Self {
+        Self {
+            list: value.iter().map(|s| Cow::Borrowed(*s)).collect(),
+        }
+    }
 }
 
-implement_from!(
-    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
-    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
-    0x20
-);
+impl<'a, const N: usize> From<&[&'a str; N]> for Codecs<'a> {
+    fn from(value: &[&'a str; N]) -> Self {
+        Self {
+            list: value.iter().map(|s| Cow::Borrowed(*s)).collect(),
+        }
+    }
+}
 
 impl fmt::Display for Codecs<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/types/decryption_key.rs
+++ b/src/types/decryption_key.rs
@@ -294,7 +294,9 @@ mod test {
             DecryptionKey::builder()
                 .method(EncryptionMethod::Aes128)
                 .uri("https://www.example.com/")
-                .iv([16, 239, 143, 117, 140, 165, 85, 17, 85, 132, 187, 91, 60, 104, 127, 82])
+                .iv([
+                    16, 239, 143, 117, 140, 165, 85, 17, 85, 132, 187, 91, 60, 104, 127, 82
+                ])
                 .format(KeyFormat::Identity)
                 .versions(vec![1, 2, 3, 4, 5])
                 .build()
@@ -303,10 +305,12 @@ mod test {
         );
 
         assert!(DecryptionKey::builder().build().is_err());
-        assert!(DecryptionKey::builder()
-            .method(EncryptionMethod::Aes128)
-            .build()
-            .is_err());
+        assert!(
+            DecryptionKey::builder()
+                .method(EncryptionMethod::Aes128)
+                .build()
+                .is_err()
+        );
     }
 
     generate_tests! {

--- a/src/types/encryption_method.rs
+++ b/src/types/encryption_method.rs
@@ -2,7 +2,6 @@ use strum::{Display, EnumString};
 
 /// The encryption method.
 #[non_exhaustive]
-#[allow(missing_docs)]
 #[derive(Ord, PartialOrd, Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString)]
 #[strum(serialize_all = "SCREAMING-KEBAB-CASE")]
 pub enum EncryptionMethod {

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -201,7 +201,7 @@ mod tests {
     use core::hash::{Hash, Hasher};
     use pretty_assertions::assert_eq;
 
-    #[allow(clippy::all, clippy::unreadable_literal)]
+    #[expect(clippy::unreadable_literal)]
     const PI: f32 = 3.14159265359;
 
     #[test]
@@ -228,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::unit_cmp)] // fucked test
+    #[expect(clippy::unit_cmp)] // fucked test
     fn test_hash() {
         let mut hasher_left = std::collections::hash_map::DefaultHasher::new();
         let mut hasher_right = std::collections::hash_map::DefaultHasher::new();

--- a/src/types/in_stream_id.rs
+++ b/src/types/in_stream_id.rs
@@ -18,7 +18,7 @@ use crate::types::ProtocolVersion;
 /// [`MediaSegment`]: crate::MediaSegment
 /// [`MediaPlaylist`]: crate::MediaPlaylist
 #[non_exhaustive]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Ord, PartialOrd, Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString)]
 #[strum(serialize_all = "UPPERCASE")]
 pub enum InStreamId {

--- a/src/types/initialization_vector.rs
+++ b/src/types/initialization_vector.rs
@@ -295,14 +295,18 @@ mod tests {
         );
 
         // missing `0x` at the start:
-        assert!("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-            .parse::<InitializationVector>()
-            .is_err());
+        assert!(
+            "0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+                .parse::<InitializationVector>()
+                .is_err()
+        );
         // too small:
         assert!("0xFF".parse::<InitializationVector>().is_err());
         // too large:
-        assert!("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-            .parse::<InitializationVector>()
-            .is_err());
+        assert!(
+            "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+                .parse::<InitializationVector>()
+                .is_err()
+        );
     }
 }

--- a/src/types/key_format_versions.rs
+++ b/src/types/key_format_versions.rs
@@ -6,10 +6,10 @@ use std::ops::{Index, IndexMut};
 use std::slice::SliceIndex;
 use std::str::FromStr;
 
-use crate::types::ProtocolVersion;
-use crate::utils::{quote, unquote};
 use crate::Error;
 use crate::RequiredVersion;
+use crate::types::ProtocolVersion;
+use crate::utils::{quote, unquote};
 
 /// A list of numbers that can be used to indicate which version(s)
 /// this instance complies with, if more than one version of a particular

--- a/src/types/key_format_versions.rs
+++ b/src/types/key_format_versions.rs
@@ -483,7 +483,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
-    #[allow(clippy::unit_cmp)] // fucked test
+    #[expect(clippy::unit_cmp)] // fucked test
     fn test_hash() {
         let mut hasher_left = std::collections::hash_map::DefaultHasher::new();
         let mut hasher_right = std::collections::hash_map::DefaultHasher::new();

--- a/src/types/media_type.rs
+++ b/src/types/media_type.rs
@@ -2,7 +2,7 @@ use strum::{Display, EnumString};
 
 /// Specifies the media type.
 #[non_exhaustive]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Ord, PartialOrd, Display, EnumString, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[strum(serialize_all = "SCREAMING-KEBAB-CASE")]
 pub enum MediaType {

--- a/src/types/protocol_version.rs
+++ b/src/types/protocol_version.rs
@@ -6,7 +6,7 @@ use crate::Error;
 /// The [`ProtocolVersion`] specifies which `m3u8` revision is required, to
 /// parse a certain tag correctly.
 #[non_exhaustive]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ProtocolVersion {
     V1,

--- a/src/types/ufloat.rs
+++ b/src/types/ufloat.rs
@@ -211,7 +211,7 @@ mod tests {
     use core::hash::{Hash, Hasher};
     use pretty_assertions::assert_eq;
 
-    #[allow(clippy::all, clippy::unreadable_literal)]
+    #[expect(clippy::unreadable_literal)]
     const PI: f32 = 3.14159265359;
 
     #[test]
@@ -232,7 +232,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::unit_cmp)] // fucked test
+    #[expect(clippy::unit_cmp)] // fucked test
     fn test_hash() {
         let mut hasher_left = std::collections::hash_map::DefaultHasher::new();
         let mut hasher_right = std::collections::hash_map::DefaultHasher::new();

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt;
 
+use crate::Error;
 use crate::types::Float;
 use crate::utils::{quote, unquote};
-use crate::Error;
 
 /// A `Value`.
 #[non_exhaustive]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,20 +25,12 @@ pub(crate) trait BoolExt {
 impl BoolExt for bool {
     #[inline]
     fn athen_some<T>(self, t: T) -> Option<T> {
-        if self {
-            Some(t)
-        } else {
-            None
-        }
+        if self { Some(t) } else { None }
     }
 
     #[inline]
     fn athen<T, F: FnOnce() -> T>(self, f: F) -> Option<T> {
-        if self {
-            Some(f())
-        } else {
-            None
-        }
+        if self { Some(f()) } else { None }
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,7 +79,7 @@ pub(crate) fn unquote(value: &str) -> Cow<'_, str> {
 }
 
 /// Puts a string inside quotes.
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 pub(crate) fn quote<T: ToString>(value: T) -> String {
     // the replace is for the case, that quote is called on an already quoted
     // string, which could cause problems!

--- a/tests/master_playlist.rs
+++ b/tests/master_playlist.rs
@@ -1,8 +1,8 @@
 use std::convert::TryFrom;
 
+use hls_m3u8::MasterPlaylist;
 use hls_m3u8::tags::{ExtXMedia, VariantStream};
 use hls_m3u8::types::{MediaType, StreamData};
-use hls_m3u8::MasterPlaylist;
 
 use pretty_assertions::assert_eq;
 

--- a/tests/version-number.rs
+++ b/tests/version-number.rs
@@ -1,9 +1,0 @@
-#[test]
-fn test_readme_deps() {
-    version_sync::assert_markdown_deps_updated!("README.md");
-}
-
-#[test]
-fn test_html_root_url() {
-    version_sync::assert_html_root_url_updated!("src/lib.rs");
-}


### PR DESCRIPTION
- Bump `edition` to 2024 and add `rust-version = "1.88"`
- Drop `html_root_url` and the `version-sync` dev-dependency
- Replace `#[allow(...)]` with `#[expect(...)]` throughout; refactor where the expectation can't be fulfilled inside macros
  - `types/codecs.rs`: replace the per-size macro with a const-generic impl
  - `types/byte_range.rs`: split out a dedicated `usize` impl to avoid the trivial-cast warning
- Drop overly broad `clippy::all` expects in favor of the specific lints that actually fire
- Reformat README for clarity
- Refresh CI (`actions/checkout@v6`, add `rustup default`, split out a Lints job)

