### PR TITLE
Replace derive_builder and shorthand with hand-written code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,5 @@ categories = ["parser-implementations"]
 
 [dependencies]
 chrono = { version = "0.4", optional = true }
-derive_builder = "0.20"
-stable-vec = { version = "0.4" }
+stable-vec = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,5 @@ categories = ["parser-implementations"]
 [dependencies]
 chrono = { version = "0.4", optional = true }
 derive_builder = "0.20"
-shorthand = "0.1"
 stable-vec = { version = "0.4" }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,9 +38,6 @@ enum ErrorKind {
     Chrono {
         source: chrono::ParseError,
     },
-    Builder {
-        message: String,
-    },
     InvalidHex(String),
 }
 
@@ -68,7 +65,6 @@ impl fmt::Display for ErrorKind {
             Self::UnexpectedTag { tag } => write!(f, "unexpected tag: {tag:?}"),
             #[cfg(feature = "chrono")]
             Self::Chrono { source } => write!(f, "{source}"),
-            Self::Builder { message } => write!(f, "builder error: {message}"),
             Self::InvalidHex(reason) => write!(f, "invalid hex: {reason}"),
         }
     }
@@ -182,12 +178,6 @@ impl Error {
 
     pub(crate) fn unknown_protocol_version<T: ToString>(value: T) -> Self {
         Self::new(ErrorKind::UnknownProtocolVersion(value.to_string()))
-    }
-
-    pub(crate) fn builder<T: ToString>(value: T) -> Self {
-        Self::new(ErrorKind::Builder {
-            message: value.to_string(),
-        })
     }
 
     pub(crate) fn missing_attribute<T: ToString>(value: T) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,7 @@
     clippy::collapsible_if,
     clippy::infallible_try_from,
     clippy::large_enum_variant,
-    clippy::module_name_repetitions,
-    clippy::unnecessary_operation
+    clippy::module_name_repetitions
 )]
 #![warn(
     missing_docs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,5 @@
 #![forbid(unsafe_code)]
-#![expect(
-    clippy::infallible_try_from,
-    clippy::large_enum_variant,
-    clippy::module_name_repetitions
-)]
+#![expect(clippy::infallible_try_from, clippy::large_enum_variant)]
 #![warn(
     missing_docs,
     missing_copy_implementations,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![forbid(unsafe_code)]
 #![expect(
-    clippy::collapsible_if,
     clippy::infallible_try_from,
     clippy::large_enum_variant,
     clippy::module_name_repetitions

--- a/src/master_playlist.rs
+++ b/src/master_playlist.rs
@@ -3,8 +3,6 @@ use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::fmt;
 
-use derive_builder::Builder;
-
 use crate::line::{Line, Lines, Tag};
 use crate::tags::{
     ExtM3u, ExtXIndependentSegments, ExtXMedia, ExtXSessionData, ExtXSessionKey, ExtXStart,
@@ -94,9 +92,7 @@ use crate::{Error, RequiredVersion};
 /// ```
 ///
 /// [`MediaPlaylist`]: crate::MediaPlaylist
-#[derive(Builder, Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[builder(build_fn(validate = "Self::validate"))]
-#[builder(setter(into, strip_option))]
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub struct MasterPlaylist<'a> {
     /// Indicates that all media samples in a [`MediaSegment`] can be
@@ -110,7 +106,6 @@ pub struct MasterPlaylist<'a> {
     ///
     /// [`MediaSegment`]: crate::MediaSegment
     /// [`MediaPlaylist`]: crate::MediaPlaylist
-    #[builder(default)]
     pub has_independent_segments: bool,
     /// A preferred point at which to start playing a playlist.
     ///
@@ -118,7 +113,6 @@ pub struct MasterPlaylist<'a> {
     ///
     /// This field is optional and by default the playlist should be played from
     /// the start.
-    #[builder(default)]
     pub start: Option<ExtXStart>,
     /// A list of all [`ExtXMedia`] tags, which describe an alternative
     /// rendition.
@@ -134,14 +128,12 @@ pub struct MasterPlaylist<'a> {
     /// This field is optional.
     ///
     /// [`MediaPlaylist`]: crate::MediaPlaylist
-    #[builder(default)]
     pub media: Vec<ExtXMedia<'a>>,
     /// A list of all streams of this [`MasterPlaylist`].
     ///
     /// ### Note
     ///
     /// This field is optional.
-    #[builder(default)]
     pub variant_streams: Vec<VariantStream<'a>>,
     /// The [`ExtXSessionData`] tag allows arbitrary session data to be
     /// carried in a [`MasterPlaylist`].
@@ -149,7 +141,6 @@ pub struct MasterPlaylist<'a> {
     /// ### Note
     ///
     /// This field is optional.
-    #[builder(default)]
     pub session_data: Vec<ExtXSessionData<'a>>,
     /// A list of [`ExtXSessionKey`]s, that allows the client to preload
     /// these keys without having to read the [`MediaPlaylist`]s first.
@@ -159,15 +150,25 @@ pub struct MasterPlaylist<'a> {
     /// This field is optional.
     ///
     /// [`MediaPlaylist`]: crate::MediaPlaylist
-    #[builder(default)]
     pub session_keys: Vec<ExtXSessionKey<'a>>,
     /// A list of all tags that could not be identified while parsing the input.
     ///
     /// ### Note
     ///
     /// This field is optional.
-    #[builder(default)]
     pub unknown_tags: Vec<Cow<'a, str>>,
+}
+
+/// Builder for [`MasterPlaylist`].
+#[derive(Debug, Clone, Default)]
+pub struct MasterPlaylistBuilder<'a> {
+    has_independent_segments: Option<bool>,
+    start: Option<ExtXStart>,
+    media: Option<Vec<ExtXMedia<'a>>>,
+    variant_streams: Option<Vec<VariantStream<'a>>>,
+    session_data: Option<Vec<ExtXSessionData<'a>>>,
+    session_keys: Option<Vec<ExtXSessionKey<'a>>>,
+    unknown_tags: Option<Vec<Cow<'a, str>>>,
 }
 
 impl<'a> MasterPlaylist<'a> {
@@ -321,15 +322,55 @@ impl RequiredVersion for MasterPlaylist<'_> {
     }
 }
 
-impl MasterPlaylistBuilder<'_> {
-    fn validate(&self) -> Result<(), String> {
+impl<'a> MasterPlaylistBuilder<'a> {
+    /// See [`MasterPlaylist::has_independent_segments`].
+    pub fn has_independent_segments(&mut self, value: bool) -> &mut Self {
+        self.has_independent_segments = Some(value);
+        self
+    }
+
+    /// See [`MasterPlaylist::start`].
+    pub fn start<V: Into<ExtXStart>>(&mut self, value: V) -> &mut Self {
+        self.start = Some(value.into());
+        self
+    }
+
+    /// See [`MasterPlaylist::media`].
+    pub fn media<V: Into<Vec<ExtXMedia<'a>>>>(&mut self, value: V) -> &mut Self {
+        self.media = Some(value.into());
+        self
+    }
+
+    /// See [`MasterPlaylist::variant_streams`].
+    pub fn variant_streams<V: Into<Vec<VariantStream<'a>>>>(&mut self, value: V) -> &mut Self {
+        self.variant_streams = Some(value.into());
+        self
+    }
+
+    /// See [`MasterPlaylist::session_data`].
+    pub fn session_data<V: Into<Vec<ExtXSessionData<'a>>>>(&mut self, value: V) -> &mut Self {
+        self.session_data = Some(value.into());
+        self
+    }
+
+    /// See [`MasterPlaylist::session_keys`].
+    pub fn session_keys<V: Into<Vec<ExtXSessionKey<'a>>>>(&mut self, value: V) -> &mut Self {
+        self.session_keys = Some(value.into());
+        self
+    }
+
+    /// See [`MasterPlaylist::unknown_tags`].
+    pub fn unknown_tags<V: Into<Vec<Cow<'a, str>>>>(&mut self, value: V) -> &mut Self {
+        self.unknown_tags = Some(value.into());
+        self
+    }
+
+    fn validate(&self) -> crate::Result<()> {
         if let Some(variant_streams) = &self.variant_streams {
-            self.validate_variants(variant_streams)
-                .map_err(|e| e.to_string())?;
+            self.validate_variants(variant_streams)?;
         }
 
-        self.validate_session_data_tags()
-            .map_err(|e| e.to_string())?;
+        self.validate_session_data_tags()?;
 
         Ok(())
     }
@@ -420,19 +461,34 @@ impl MasterPlaylistBuilder<'_> {
             })
         })
     }
+
+    /// Builds a new [`MasterPlaylist`].
+    ///
+    /// # Errors
+    ///
+    /// If validation fails.
+    pub fn build(&self) -> Result<MasterPlaylist<'a>, Error> {
+        self.validate()?;
+
+        Ok(MasterPlaylist {
+            has_independent_segments: self.has_independent_segments.unwrap_or(false),
+            start: self.start,
+            media: self.media.clone().unwrap_or_default(),
+            variant_streams: self.variant_streams.clone().unwrap_or_default(),
+            session_data: self.session_data.clone().unwrap_or_default(),
+            session_keys: self.session_keys.clone().unwrap_or_default(),
+            unknown_tags: self.unknown_tags.clone().unwrap_or_default(),
+        })
+    }
 }
 
 impl RequiredVersion for MasterPlaylistBuilder<'_> {
     fn required_version(&self) -> ProtocolVersion {
-        // TODO: the .flatten() can be removed as soon as `recursive traits` are
-        //       supported. (RequiredVersion is implemented for Option<T>, but
-        //       not for Option<Option<T>>)
-        // https://github.com/rust-lang/chalk/issues/12
         required_version![
             self.has_independent_segments
                 .unwrap_or(false)
                 .athen_some(ExtXIndependentSegments),
-            self.start.flatten(),
+            self.start,
             self.media,
             self.variant_streams,
             self.session_data,
@@ -557,7 +613,7 @@ impl<'a> TryFrom<&'a str> for MasterPlaylist<'a> {
         builder.session_keys(session_keys);
         builder.unknown_tags(unknown_tags);
 
-        builder.build().map_err(Error::builder)
+        builder.build()
     }
 }
 

--- a/src/master_playlist.rs
+++ b/src/master_playlist.rs
@@ -346,22 +346,22 @@ impl MasterPlaylistBuilder<'_> {
                     stream_data,
                     ..
                 } => {
-                    if let Some(group_id) = &audio {
-                        if !self.check_media_group(MediaType::Audio, group_id) {
-                            return Err(Error::unmatched_group(group_id));
-                        }
+                    if let Some(group_id) = &audio
+                        && !self.check_media_group(MediaType::Audio, group_id)
+                    {
+                        return Err(Error::unmatched_group(group_id));
                     }
 
-                    if let Some(group_id) = &stream_data.video() {
-                        if !self.check_media_group(MediaType::Video, group_id) {
-                            return Err(Error::unmatched_group(group_id));
-                        }
+                    if let Some(group_id) = &stream_data.video()
+                        && !self.check_media_group(MediaType::Video, group_id)
+                    {
+                        return Err(Error::unmatched_group(group_id));
                     }
 
-                    if let Some(group_id) = &subtitles {
-                        if !self.check_media_group(MediaType::Subtitles, group_id) {
-                            return Err(Error::unmatched_group(group_id));
-                        }
+                    if let Some(group_id) = &subtitles
+                        && !self.check_media_group(MediaType::Subtitles, group_id)
+                    {
+                        return Err(Error::unmatched_group(group_id));
                     }
 
                     if let Some(closed_captions) = &closed_captions {
@@ -385,10 +385,10 @@ impl MasterPlaylistBuilder<'_> {
                 }
 
                 VariantStream::ExtXIFrame { stream_data, .. } => {
-                    if let Some(group_id) = stream_data.video() {
-                        if !self.check_media_group(MediaType::Video, group_id) {
-                            return Err(Error::unmatched_group(group_id));
-                        }
+                    if let Some(group_id) = stream_data.video()
+                        && !self.check_media_group(MediaType::Video, group_id)
+                    {
+                        return Err(Error::unmatched_group(group_id));
                     }
                 }
             }

--- a/src/media_playlist.rs
+++ b/src/media_playlist.rs
@@ -5,7 +5,6 @@ use std::fmt;
 use std::str::FromStr;
 use std::time::Duration;
 
-use derive_builder::Builder;
 use stable_vec::StableVec;
 
 use crate::line::{Line, Lines, Tag};
@@ -22,8 +21,7 @@ use crate::utils::{BoolExt, tag};
 use crate::{Error, RequiredVersion};
 
 /// Media playlist.
-#[derive(Builder, Debug, Clone, PartialEq, Eq)]
-#[builder(build_fn(skip), setter(strip_option))]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct MediaPlaylist<'a> {
     /// Specifies the maximum [`MediaSegment::duration`]. A typical target
@@ -39,7 +37,6 @@ pub struct MediaPlaylist<'a> {
     /// ### Note
     ///
     /// This field is optional and by default a value of 0 is assumed.
-    #[builder(default)]
     pub media_sequence: usize,
     /// Allows synchronization between different renditions of the same
     /// [`VariantStream`].
@@ -49,7 +46,6 @@ pub struct MediaPlaylist<'a> {
     /// This field is optional and by default a vaule of 0 is assumed.
     ///
     /// [`VariantStream`]: crate::tags::VariantStream
-    #[builder(default)]
     pub discontinuity_sequence: usize,
     /// Provides mutability information about a [`MediaPlaylist`].
     ///
@@ -61,7 +57,6 @@ pub struct MediaPlaylist<'a> {
     /// ### Note
     ///
     /// This field is optional.
-    #[builder(default, setter(into))]
     pub playlist_type: Option<PlaylistType>,
     /// Indicates that each [`MediaSegment`] in the playlist describes a single
     /// I-frame. I-frames are encoded video frames, whose decoding does not
@@ -71,7 +66,6 @@ pub struct MediaPlaylist<'a> {
     /// ### Note
     ///
     /// This field is optional.
-    #[builder(default)]
     pub has_i_frames_only: bool,
     /// This indicates that all media samples in a [`MediaSegment`] can be
     /// decoded without information from other segments.
@@ -80,7 +74,6 @@ pub struct MediaPlaylist<'a> {
     ///
     /// This field is optional and by default `false`. If the value is `true` it
     /// applies to every [`MediaSegment`] in this [`MediaPlaylist`].
-    #[builder(default)]
     pub has_independent_segments: bool,
     /// Indicates a preferred point at which to start playing a playlist. By
     /// default, clients should start playback at this point when beginning a
@@ -89,7 +82,6 @@ pub struct MediaPlaylist<'a> {
     /// ### Note
     ///
     /// This field is optional.
-    #[builder(default, setter(into))]
     pub start: Option<ExtXStart>,
     /// Indicates that no more [`MediaSegment`]s will be added to the
     /// [`MediaPlaylist`] file.
@@ -100,14 +92,12 @@ pub struct MediaPlaylist<'a> {
     /// A `false` indicates that the client should reload the [`MediaPlaylist`]
     /// from the server, until a playlist is encountered, where this field is
     /// `true`.
-    #[builder(default)]
     pub has_end_list: bool,
     /// A list of all [`MediaSegment`]s.
     ///
     /// ### Note
     ///
     /// This field is required.
-    #[builder(setter(custom))]
     pub segments: StableVec<MediaSegment<'a>>,
     /// The allowable excess duration of each media segment in the
     /// associated playlist.
@@ -123,22 +113,95 @@ pub struct MediaPlaylist<'a> {
     ///
     /// This field is optional and the default value is
     /// `Duration::from_secs(0)`.
-    #[builder(default = "Duration::from_secs(0)")]
     pub allowable_excess_duration: Duration,
     /// A list of unknown tags.
     ///
     /// ### Note
     ///
     /// This field is optional.
-    #[builder(default, setter(into))]
     pub unknown: Vec<Cow<'a, str>>,
 }
 
+/// Builder for [`MediaPlaylist`].
+#[derive(Debug, Clone, Default)]
+pub struct MediaPlaylistBuilder<'a> {
+    target_duration: Option<Duration>,
+    media_sequence: Option<usize>,
+    discontinuity_sequence: Option<usize>,
+    playlist_type: Option<PlaylistType>,
+    has_i_frames_only: Option<bool>,
+    has_independent_segments: Option<bool>,
+    start: Option<ExtXStart>,
+    has_end_list: Option<bool>,
+    segments: Option<StableVec<MediaSegment<'a>>>,
+    allowable_excess_duration: Option<Duration>,
+    unknown: Option<Vec<Cow<'a, str>>>,
+}
+
 impl<'a> MediaPlaylistBuilder<'a> {
-    fn validate(&self) -> Result<(), String> {
+    /// See [`MediaPlaylist::target_duration`].
+    pub fn target_duration(&mut self, value: Duration) -> &mut Self {
+        self.target_duration = Some(value);
+        self
+    }
+
+    /// See [`MediaPlaylist::media_sequence`].
+    pub fn media_sequence(&mut self, value: usize) -> &mut Self {
+        self.media_sequence = Some(value);
+        self
+    }
+
+    /// See [`MediaPlaylist::discontinuity_sequence`].
+    pub fn discontinuity_sequence(&mut self, value: usize) -> &mut Self {
+        self.discontinuity_sequence = Some(value);
+        self
+    }
+
+    /// See [`MediaPlaylist::playlist_type`].
+    pub fn playlist_type<V: Into<PlaylistType>>(&mut self, value: V) -> &mut Self {
+        self.playlist_type = Some(value.into());
+        self
+    }
+
+    /// See [`MediaPlaylist::has_i_frames_only`].
+    pub fn has_i_frames_only(&mut self, value: bool) -> &mut Self {
+        self.has_i_frames_only = Some(value);
+        self
+    }
+
+    /// See [`MediaPlaylist::has_independent_segments`].
+    pub fn has_independent_segments(&mut self, value: bool) -> &mut Self {
+        self.has_independent_segments = Some(value);
+        self
+    }
+
+    /// See [`MediaPlaylist::start`].
+    pub fn start<V: Into<ExtXStart>>(&mut self, value: V) -> &mut Self {
+        self.start = Some(value.into());
+        self
+    }
+
+    /// See [`MediaPlaylist::has_end_list`].
+    pub fn has_end_list(&mut self, value: bool) -> &mut Self {
+        self.has_end_list = Some(value);
+        self
+    }
+
+    /// See [`MediaPlaylist::allowable_excess_duration`].
+    pub fn allowable_excess_duration(&mut self, value: Duration) -> &mut Self {
+        self.allowable_excess_duration = Some(value);
+        self
+    }
+
+    /// See [`MediaPlaylist::unknown`].
+    pub fn unknown<V: Into<Vec<Cow<'a, str>>>>(&mut self, value: V) -> &mut Self {
+        self.unknown = Some(value.into());
+        self
+    }
+
+    fn validate(&self) -> Result<(), Error> {
         if let Some(target_duration) = &self.target_duration {
-            self.validate_media_segments(*target_duration)
-                .map_err(|e| e.to_string())?;
+            self.validate_media_segments(*target_duration)?;
         }
 
         Ok(())
@@ -280,7 +343,7 @@ impl<'a> MediaPlaylistBuilder<'a> {
     /// # Errors
     ///
     /// If a required field has not been initialized.
-    pub fn build(&self) -> Result<MediaPlaylist<'a>, String> {
+    pub fn build(&self) -> Result<MediaPlaylist<'a>, Error> {
         // validate builder
         self.validate()?;
 
@@ -289,17 +352,17 @@ impl<'a> MediaPlaylistBuilder<'a> {
         let mut segments = self
             .segments
             .clone()
-            .ok_or_else(|| "missing field `segments`".to_string())?;
+            .ok_or_else(|| Error::missing_field("MediaPlaylist", "segments"))?;
 
         // no segment should exist before the sequence_number
         if let Some(first_segment) = segments.find_first()
             && sequence_number > first_segment.number
             && first_segment.explicit_number
         {
-            return Err(format!(
+            return Err(Error::custom(format!(
                 "there should be no segment ({}) before the sequence_number ({})",
                 first_segment, sequence_number,
-            ));
+            )));
         }
 
         let mut previous_range: Option<ExtXByteRange> = None;
@@ -340,27 +403,20 @@ impl<'a> MediaPlaylistBuilder<'a> {
             }
         }
 
-        // TODO: can segments be missing?
         if !segments.is_compact() {
-            // find the missing segment by iterating through all segments:
-            // let missing = segments
-            //     .iter()
-            //     .enumerate()
-            //     .find_map(|(i, e)| e.is_none().athen(i))
-            //     .unwrap();
-            return Err("a segment is missing".to_string());
+            return Err(Error::custom("a segment is missing"));
         }
 
         Ok(MediaPlaylist {
             target_duration: self
                 .target_duration
-                .ok_or_else(|| "missing field `target_duration`".to_string())?,
+                .ok_or_else(|| Error::missing_field("MediaPlaylist", "target_duration"))?,
             media_sequence: self.media_sequence.unwrap_or(0),
             discontinuity_sequence: self.discontinuity_sequence.unwrap_or(0),
-            playlist_type: self.playlist_type.unwrap_or(None),
+            playlist_type: self.playlist_type,
             has_i_frames_only: self.has_i_frames_only.unwrap_or(false),
             has_independent_segments: self.has_independent_segments.unwrap_or(false),
-            start: self.start.unwrap_or(None),
+            start: self.start,
             has_end_list: self.has_end_list.unwrap_or(false),
             segments,
             allowable_excess_duration: self
@@ -709,7 +765,7 @@ fn parse_media_playlist<'a>(
             Line::Uri(uri) => {
                 segment.uri(uri);
                 segment.keys(available_keys.iter().cloned().collect::<Vec<_>>());
-                segments.push(segment.build().map_err(Error::builder)?);
+                segments.push(segment.build()?);
 
                 segment = MediaSegment::builder();
                 has_partial_segment = false;
@@ -724,7 +780,7 @@ fn parse_media_playlist<'a>(
 
     builder.unknown(unknown);
     builder.segments(segments);
-    builder.build().map_err(Error::builder)
+    builder.build()
 }
 
 impl FromStr for MediaPlaylist<'static> {

--- a/src/media_playlist.rs
+++ b/src/media_playlist.rs
@@ -292,13 +292,14 @@ impl<'a> MediaPlaylistBuilder<'a> {
             .ok_or_else(|| "missing field `segments`".to_string())?;
 
         // no segment should exist before the sequence_number
-        if let Some(first_segment) = segments.find_first() {
-            if sequence_number > first_segment.number && first_segment.explicit_number {
-                return Err(format!(
-                    "there should be no segment ({}) before the sequence_number ({})",
-                    first_segment, sequence_number,
-                ));
-            }
+        if let Some(first_segment) = segments.find_first()
+            && sequence_number > first_segment.number
+            && first_segment.explicit_number
+        {
+            return Err(format!(
+                "there should be no segment ({}) before the sequence_number ({})",
+                first_segment, sequence_number,
+            ));
         }
 
         let mut previous_range: Option<ExtXByteRange> = None;
@@ -314,13 +315,11 @@ impl<'a> MediaPlaylistBuilder<'a> {
                 if let ExtXKey(Some(DecryptionKey {
                     method, iv, format, ..
                 })) = key
+                    && *method == EncryptionMethod::Aes128
+                    && *iv == InitializationVector::Missing
+                    && (format.is_none() || &mut Some(KeyFormat::Identity) == format)
                 {
-                    if *method == EncryptionMethod::Aes128
-                        && *iv == InitializationVector::Missing
-                        && (format.is_none() || &mut Some(KeyFormat::Identity) == format)
-                    {
-                        *iv = InitializationVector::Number(segment.number as u128);
-                    }
+                    *iv = InitializationVector::Number(segment.number as u128);
                 }
             }
 

--- a/src/media_segment.rs
+++ b/src/media_segment.rs
@@ -1,13 +1,11 @@
 use std::borrow::Cow;
 use std::fmt;
 
-use derive_builder::Builder;
-
 use crate::tags::{
     ExtInf, ExtXByteRange, ExtXDateRange, ExtXDiscontinuity, ExtXKey, ExtXMap, ExtXProgramDateTime,
 };
 use crate::types::{DecryptionKey, ProtocolVersion};
-use crate::{Decryptable, RequiredVersion};
+use crate::{Decryptable, Error, RequiredVersion};
 
 /// A video is split into smaller chunks called [`MediaSegment`]s, which are
 /// specified by a uri and optionally a byte range.
@@ -31,29 +29,9 @@ use crate::{Decryptable, RequiredVersion};
 /// IDR will be downloaded but possibly discarded.
 ///
 /// [`MediaPlaylist`]: crate::MediaPlaylist
-#[derive(Debug, Clone, Builder, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[builder(setter(strip_option))]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MediaSegment<'a> {
-    /// Each [`MediaSegment`] has a number, which allows synchronization between
-    /// different variants.
-    ///
-    /// ## Note
-    ///
-    /// This number must not be specified, because it will be assigned
-    /// automatically by [`MediaPlaylistBuilder::segments`]. The first
-    /// [`MediaSegment::number`] in a [`MediaPlaylist`] will either be 0 or the
-    /// number returned by the [`ExtXDiscontinuitySequence`] if one is
-    /// provided.
-    /// The following segments will be the previous segment number + 1.
-    ///
-    /// [`MediaPlaylistBuilder::segments`]:
-    /// crate::builder::MediaPlaylistBuilder::segments
-    /// [`MediaPlaylist`]: crate::MediaPlaylist
-    /// [`ExtXMediaSequence`]: crate::tags::ExtXMediaSequence
-    /// [`ExtXDiscontinuitySequence`]: crate::tags::ExtXDiscontinuitySequence
-    #[builder(default, setter(custom))]
     pub(crate) number: usize,
-    #[builder(default, setter(custom))]
     pub(crate) explicit_number: bool,
     /// This field specifies how to decrypt a [`MediaSegment`], which can only
     /// be encrypted with one [`EncryptionMethod`], using one [`DecryptionKey`]
@@ -77,7 +55,6 @@ pub struct MediaSegment<'a> {
     /// [`ExtXMap`]: crate::tags::ExtXMap
     /// [`KeyFormat`]: crate::types::KeyFormat
     /// [`EncryptionMethod`]: crate::types::EncryptionMethod
-    #[builder(default, setter(into))]
     pub keys: Vec<ExtXKey<'a>>,
     /// This field specifies how to obtain the Media Initialization Section
     /// required to parse the applicable `MediaSegment`s.
@@ -91,7 +68,6 @@ pub struct MediaSegment<'a> {
     /// Media Initialization Section at the beginning of its resource.
     ///
     /// [`ExtXIFramesOnly`]: crate::tags::ExtXIFramesOnly
-    #[builder(default)]
     pub map: Option<ExtXMap<'a>>,
     /// This field indicates that a `MediaSegment` is a sub-range of the
     /// resource identified by its URI.
@@ -99,7 +75,6 @@ pub struct MediaSegment<'a> {
     /// ## Note
     ///
     /// This field is optional.
-    #[builder(default, setter(into))]
     pub byte_range: Option<ExtXByteRange>,
     /// This field associates a date-range (i.e., a range of time defined by a
     /// starting and ending date) with a set of attribute/value pairs.
@@ -107,7 +82,6 @@ pub struct MediaSegment<'a> {
     /// ## Note
     ///
     /// This field is optional.
-    #[builder(default)]
     pub date_range: Option<ExtXDateRange<'a>>,
     /// This field indicates a discontinuity between the `MediaSegment` that
     /// follows it and the one that preceded it.
@@ -123,7 +97,6 @@ pub struct MediaSegment<'a> {
     /// change:
     /// - encoding parameters
     /// - encoding sequence
-    #[builder(default)]
     pub has_discontinuity: bool,
     /// This field associates the first sample of a media segment with an
     /// absolute date and/or time.
@@ -131,18 +104,29 @@ pub struct MediaSegment<'a> {
     /// ## Note
     ///
     /// This field is optional.
-    #[builder(default)]
     pub program_date_time: Option<ExtXProgramDateTime<'a>>,
     /// This field indicates the duration of a media segment.
     ///
     /// ## Note
     ///
     /// This field is required.
-    #[builder(setter(into))]
     pub duration: ExtInf<'a>,
-    /// See [`MediaSegment::uri`].
-    #[builder(setter(into))]
     uri: Cow<'a, str>,
+}
+
+/// Builder for a [`MediaSegment`].
+#[derive(Debug, Clone, Default)]
+pub struct MediaSegmentBuilder<'a> {
+    number: Option<usize>,
+    explicit_number: Option<bool>,
+    keys: Option<Vec<ExtXKey<'a>>>,
+    map: Option<ExtXMap<'a>>,
+    byte_range: Option<ExtXByteRange>,
+    date_range: Option<ExtXDateRange<'a>>,
+    has_discontinuity: Option<bool>,
+    program_date_time: Option<ExtXProgramDateTime<'a>>,
+    duration: Option<ExtInf<'a>>,
+    uri: Option<Cow<'a, str>>,
 }
 
 impl<'a> MediaSegment<'a> {
@@ -219,17 +203,6 @@ impl MediaSegment<'_> {
 }
 
 impl<'a> MediaSegmentBuilder<'a> {
-    /// Pushes an [`ExtXKey`] tag.
-    pub fn push_key<VALUE: Into<ExtXKey<'a>>>(&mut self, value: VALUE) -> &mut Self {
-        if let Some(keys) = &mut self.keys {
-            keys.push(value.into());
-        } else {
-            self.keys = Some(vec![value.into()]);
-        }
-
-        self
-    }
-
     /// The number of a [`MediaSegment`]. Normally this should not be set
     /// explicitly, because the [`MediaPlaylist::builder`] will automatically
     /// apply the correct number.
@@ -238,8 +211,90 @@ impl<'a> MediaSegmentBuilder<'a> {
     pub fn number(&mut self, value: Option<usize>) -> &mut Self {
         self.number = value;
         self.explicit_number = Some(value.is_some());
-
         self
+    }
+
+    /// See [`MediaSegment::keys`].
+    pub fn keys<V: Into<Vec<ExtXKey<'a>>>>(&mut self, value: V) -> &mut Self {
+        self.keys = Some(value.into());
+        self
+    }
+
+    /// Pushes an [`ExtXKey`] tag.
+    pub fn push_key<V: Into<ExtXKey<'a>>>(&mut self, value: V) -> &mut Self {
+        self.keys.get_or_insert_with(Vec::new).push(value.into());
+        self
+    }
+
+    /// See [`MediaSegment::map`].
+    pub fn map(&mut self, value: ExtXMap<'a>) -> &mut Self {
+        self.map = Some(value);
+        self
+    }
+
+    /// See [`MediaSegment::byte_range`].
+    pub fn byte_range<V: Into<ExtXByteRange>>(&mut self, value: V) -> &mut Self {
+        self.byte_range = Some(value.into());
+        self
+    }
+
+    /// See [`MediaSegment::date_range`].
+    pub fn date_range(&mut self, value: ExtXDateRange<'a>) -> &mut Self {
+        self.date_range = Some(value);
+        self
+    }
+
+    /// See [`MediaSegment::has_discontinuity`].
+    pub fn has_discontinuity(&mut self, value: bool) -> &mut Self {
+        self.has_discontinuity = Some(value);
+        self
+    }
+
+    /// See [`MediaSegment::program_date_time`].
+    pub fn program_date_time(&mut self, value: ExtXProgramDateTime<'a>) -> &mut Self {
+        self.program_date_time = Some(value);
+        self
+    }
+
+    /// See [`MediaSegment::duration`].
+    pub fn duration<V: Into<ExtInf<'a>>>(&mut self, value: V) -> &mut Self {
+        self.duration = Some(value.into());
+        self
+    }
+
+    /// See [`MediaSegment::uri`].
+    pub fn uri<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.uri = Some(value.into());
+        self
+    }
+
+    /// Builds a new [`MediaSegment`].
+    ///
+    /// # Errors
+    ///
+    /// If a required field has not been initialized.
+    pub fn build(&self) -> Result<MediaSegment<'a>, Error> {
+        Ok(MediaSegment {
+            number: self.number.unwrap_or(0),
+            explicit_number: self.explicit_number.unwrap_or(false),
+            keys: self.keys.clone().unwrap_or_default(),
+            map: self.map.clone(),
+            byte_range: self.byte_range,
+            date_range: self.date_range.clone(),
+            has_discontinuity: self.has_discontinuity.unwrap_or(false),
+            #[cfg(feature = "chrono")]
+            program_date_time: self.program_date_time,
+            #[cfg(not(feature = "chrono"))]
+            program_date_time: self.program_date_time.clone(),
+            duration: self
+                .duration
+                .clone()
+                .ok_or_else(|| Error::missing_field("MediaSegment", "duration"))?,
+            uri: self
+                .uri
+                .clone()
+                .ok_or_else(|| Error::missing_field("MediaSegment", "uri"))?,
+        })
     }
 }
 

--- a/src/media_segment.rs
+++ b/src/media_segment.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::fmt;
 
 use derive_builder::Builder;
-use shorthand::ShortHand;
 
 use crate::tags::{
     ExtInf, ExtXByteRange, ExtXDateRange, ExtXDiscontinuity, ExtXKey, ExtXMap, ExtXProgramDateTime,
@@ -32,9 +31,8 @@ use crate::{Decryptable, RequiredVersion};
 /// IDR will be downloaded but possibly discarded.
 ///
 /// [`MediaPlaylist`]: crate::MediaPlaylist
-#[derive(ShortHand, Debug, Clone, Builder, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Builder, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[builder(setter(strip_option))]
-#[shorthand(enable(must_use, skip))]
 pub struct MediaSegment<'a> {
     /// Each [`MediaSegment`] has a number, which allows synchronization between
     /// different variants.
@@ -54,7 +52,6 @@ pub struct MediaSegment<'a> {
     /// [`ExtXMediaSequence`]: crate::tags::ExtXMediaSequence
     /// [`ExtXDiscontinuitySequence`]: crate::tags::ExtXDiscontinuitySequence
     #[builder(default, setter(custom))]
-    #[shorthand(disable(set, skip))]
     pub(crate) number: usize,
     #[builder(default, setter(custom))]
     pub(crate) explicit_number: bool,
@@ -143,14 +140,33 @@ pub struct MediaSegment<'a> {
     /// This field is required.
     #[builder(setter(into))]
     pub duration: ExtInf<'a>,
+    /// See [`MediaSegment::uri`].
+    #[builder(setter(into))]
+    uri: Cow<'a, str>,
+}
+
+impl<'a> MediaSegment<'a> {
+    /// The number assigned to this segment.
+    #[must_use]
+    pub fn number(&self) -> usize {
+        self.number
+    }
+
     /// The URI of a media segment.
     ///
     /// ## Note
     ///
     /// This field is required.
-    #[builder(setter(into))]
-    #[shorthand(enable(into), disable(skip))]
-    uri: Cow<'a, str>,
+    #[must_use]
+    pub fn uri(&self) -> &Cow<'a, str> {
+        &self.uri
+    }
+
+    /// Sets [`MediaSegment::uri`].
+    pub fn set_uri<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.uri = value.into();
+        self
+    }
 }
 
 impl MediaSegment<'_> {

--- a/src/tags/master_playlist/media.rs
+++ b/src/tags/master_playlist/media.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt;
 
-use derive_builder::Builder;
-
 use crate::attribute::AttributePairs;
 use crate::types::{Channels, InStreamId, MediaType, ProtocolVersion};
 use crate::utils::{parse_yes_or_no, quote, tag, unquote};
@@ -17,9 +15,7 @@ use crate::{Error, RequiredVersion};
 ///
 /// [`MediaPlaylist`]: crate::MediaPlaylist
 /// [`VariantStream`]: crate::tags::VariantStream
-#[derive(Builder, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[builder(setter(into))]
-#[builder(build_fn(validate = "Self::validate"))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ExtXMedia<'a> {
     /// The [`MediaType`] associated with this tag.
     ///
@@ -27,18 +23,10 @@ pub struct ExtXMedia<'a> {
     ///
     /// This field is required.
     pub media_type: MediaType,
-    /// See [`ExtXMedia::uri`].
-    #[builder(setter(strip_option), default)]
     uri: Option<Cow<'a, str>>,
-    /// See [`ExtXMedia::group_id`].
     group_id: Cow<'a, str>,
-    /// See [`ExtXMedia::language`].
-    #[builder(setter(strip_option), default)]
     language: Option<Cow<'a, str>>,
-    /// See [`ExtXMedia::assoc_language`].
-    #[builder(setter(strip_option), default)]
     assoc_language: Option<Cow<'a, str>>,
-    /// See [`ExtXMedia::name`].
     name: Cow<'a, str>,
     /// The value of the `default` flag.
     /// A value of `true` indicates, that the client should play
@@ -49,7 +37,6 @@ pub struct ExtXMedia<'a> {
     ///
     /// This field is optional, its absence indicates an implicit value
     /// of `false`.
-    #[builder(default)]
     pub is_default: bool,
     /// Whether the client may choose to play this rendition in the absence of
     /// explicit user preference.
@@ -58,11 +45,9 @@ pub struct ExtXMedia<'a> {
     ///
     /// This field is optional, its absence indicates an implicit value
     /// of `false`.
-    #[builder(default)]
     pub is_autoselect: bool,
     /// Whether the rendition contains content that is considered
     /// essential to play.
-    #[builder(default)]
     pub is_forced: bool,
     /// An [`InStreamId`] identifies a rendition within the
     /// [`MediaSegment`]s in a [`MediaPlaylist`].
@@ -75,10 +60,7 @@ pub struct ExtXMedia<'a> {
     ///
     /// [`MediaPlaylist`]: crate::MediaPlaylist
     /// [`MediaSegment`]: crate::MediaSegment
-    #[builder(setter(strip_option), default)]
     pub instream_id: Option<InStreamId>,
-    /// See [`ExtXMedia::characteristics`].
-    #[builder(setter(strip_option), default)]
     characteristics: Option<Cow<'a, str>>,
     /// A count of audio channels indicating the maximum number of independent,
     /// simultaneous audio channels present in any [`MediaSegment`] in the
@@ -93,40 +75,126 @@ pub struct ExtXMedia<'a> {
     ///
     /// [`MediaSegment`]: crate::MediaSegment
     /// [`MasterPlaylist`]: crate::MasterPlaylist
-    #[builder(setter(strip_option), default)]
     pub channels: Option<Channels>,
 }
 
-impl ExtXMediaBuilder<'_> {
-    fn validate(&self) -> Result<(), String> {
-        // A MediaType is always required!
+/// Builder for [`ExtXMedia`].
+#[derive(Debug, Clone, Default)]
+pub struct ExtXMediaBuilder<'a> {
+    media_type: Option<MediaType>,
+    uri: Option<Cow<'a, str>>,
+    group_id: Option<Cow<'a, str>>,
+    language: Option<Cow<'a, str>>,
+    assoc_language: Option<Cow<'a, str>>,
+    name: Option<Cow<'a, str>>,
+    is_default: Option<bool>,
+    is_autoselect: Option<bool>,
+    is_forced: Option<bool>,
+    instream_id: Option<InStreamId>,
+    characteristics: Option<Cow<'a, str>>,
+    channels: Option<Channels>,
+}
+
+impl<'a> ExtXMediaBuilder<'a> {
+    /// See [`ExtXMedia::media_type`].
+    pub fn media_type(&mut self, value: MediaType) -> &mut Self {
+        self.media_type = Some(value);
+        self
+    }
+
+    /// See [`ExtXMedia::uri`].
+    pub fn uri<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.uri = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXMedia::group_id`].
+    pub fn group_id<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.group_id = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXMedia::language`].
+    pub fn language<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.language = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXMedia::assoc_language`].
+    pub fn assoc_language<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.assoc_language = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXMedia::name`].
+    pub fn name<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.name = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXMedia::is_default`].
+    pub fn is_default(&mut self, value: bool) -> &mut Self {
+        self.is_default = Some(value);
+        self
+    }
+
+    /// See [`ExtXMedia::is_autoselect`].
+    pub fn is_autoselect(&mut self, value: bool) -> &mut Self {
+        self.is_autoselect = Some(value);
+        self
+    }
+
+    /// See [`ExtXMedia::is_forced`].
+    pub fn is_forced(&mut self, value: bool) -> &mut Self {
+        self.is_forced = Some(value);
+        self
+    }
+
+    /// See [`ExtXMedia::instream_id`].
+    pub fn instream_id(&mut self, value: InStreamId) -> &mut Self {
+        self.instream_id = Some(value);
+        self
+    }
+
+    /// See [`ExtXMedia::characteristics`].
+    pub fn characteristics<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.characteristics = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXMedia::channels`].
+    pub fn channels(&mut self, value: Channels) -> &mut Self {
+        self.channels = Some(value);
+        self
+    }
+
+    fn validate(&self) -> Result<MediaType, Error> {
         let media_type = self
             .media_type
-            .ok_or_else(|| Error::missing_attribute("MEDIA-TYPE").to_string())?;
+            .ok_or_else(|| Error::missing_attribute("MEDIA-TYPE"))?;
 
         if media_type == MediaType::Subtitles && self.uri.is_none() {
-            return Err(Error::missing_attribute("URI").to_string());
+            return Err(Error::missing_attribute("URI"));
         }
 
         if media_type == MediaType::ClosedCaptions {
             if self.uri.is_some() {
-                return Err(Error::unexpected_attribute("URI").to_string());
+                return Err(Error::unexpected_attribute("URI"));
             }
             if self.instream_id.is_none() {
-                return Err(Error::missing_attribute("INSTREAM-ID").to_string());
+                return Err(Error::missing_attribute("INSTREAM-ID"));
             }
         } else if self.instream_id.is_some() {
             return Err(Error::custom(
-                "InStreamId should only be specified for an ExtXMedia tag with `MediaType::ClosedCaptions`"
-            ).to_string());
+                "InStreamId should only be specified for an ExtXMedia tag with `MediaType::ClosedCaptions`",
+            ));
         }
 
         if self.is_default.unwrap_or(false) && self.is_autoselect.is_some_and(|b| !b) {
             return Err(Error::custom(format!(
                 "If `DEFAULT` is true, `AUTOSELECT` has to be true too, if present. Default: {:?}, Autoselect: {:?}!",
-                self.is_default, self.is_autoselect
-            ))
-            .to_string());
+                self.is_default, self.is_autoselect,
+            )));
         }
 
         if media_type != MediaType::Subtitles && self.is_forced.unwrap_or(false) {
@@ -136,12 +204,41 @@ impl ExtXMediaBuilder<'_> {
                     "unless the media_type is `MediaType::Subtitles`: ",
                     "media_type: {:?}, is_forced: {:?}"
                 ),
-                media_type, self.is_forced
-            ))
-            .to_string());
+                media_type, self.is_forced,
+            )));
         }
 
-        Ok(())
+        Ok(media_type)
+    }
+
+    /// Builds a new [`ExtXMedia`].
+    ///
+    /// # Errors
+    ///
+    /// If a required field has not been initialized or validation fails.
+    pub fn build(&self) -> Result<ExtXMedia<'a>, Error> {
+        let media_type = self.validate()?;
+
+        Ok(ExtXMedia {
+            media_type,
+            uri: self.uri.clone(),
+            group_id: self
+                .group_id
+                .clone()
+                .ok_or_else(|| Error::missing_field("ExtXMedia", "group_id"))?,
+            language: self.language.clone(),
+            assoc_language: self.assoc_language.clone(),
+            name: self
+                .name
+                .clone()
+                .ok_or_else(|| Error::missing_field("ExtXMedia", "name"))?,
+            is_default: self.is_default.unwrap_or(false),
+            is_autoselect: self.is_autoselect.unwrap_or(false),
+            is_forced: self.is_forced.unwrap_or(false),
+            instream_id: self.instream_id,
+            characteristics: self.characteristics.clone(),
+            channels: self.channels,
+        })
     }
 }
 
@@ -487,7 +584,7 @@ impl<'a> TryFrom<&'a str> for ExtXMedia<'a> {
             }
         }
 
-        builder.build().map_err(Error::builder)
+        builder.build()
     }
 }
 

--- a/src/tags/master_playlist/media.rs
+++ b/src/tags/master_playlist/media.rs
@@ -3,7 +3,6 @@ use std::convert::TryFrom;
 use std::fmt;
 
 use derive_builder::Builder;
-use shorthand::ShortHand;
 
 use crate::attribute::AttributePairs;
 use crate::types::{Channels, InStreamId, MediaType, ProtocolVersion};
@@ -18,8 +17,7 @@ use crate::{Error, RequiredVersion};
 ///
 /// [`MediaPlaylist`]: crate::MediaPlaylist
 /// [`VariantStream`]: crate::tags::VariantStream
-#[derive(ShortHand, Builder, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[shorthand(enable(must_use, into))]
+#[derive(Builder, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[builder(setter(into))]
 #[builder(build_fn(validate = "Self::validate"))]
 pub struct ExtXMedia<'a> {
@@ -28,66 +26,19 @@ pub struct ExtXMedia<'a> {
     /// ### Note
     ///
     /// This field is required.
-    #[shorthand(enable(skip))]
     pub media_type: MediaType,
-    /// An `URI` to a [`MediaPlaylist`].
-    ///
-    /// ### Note
-    ///
-    /// - This field is required, if the [`ExtXMedia::media_type`] is
-    ///   [`MediaType::Subtitles`].
-    /// - This field is not allowed, if the [`ExtXMedia::media_type`] is
-    ///   [`MediaType::ClosedCaptions`].
-    ///
-    /// An absent value indicates that the media data for this rendition is
-    /// included in the [`MediaPlaylist`] of any
-    /// [`VariantStream::ExtXStreamInf`] tag with the same `group_id` of
-    /// this [`ExtXMedia`] instance.
-    ///
-    /// [`MediaPlaylist`]: crate::MediaPlaylist
-    /// [`VariantStream::ExtXStreamInf`]:
-    /// crate::tags::VariantStream::ExtXStreamInf
+    /// See [`ExtXMedia::uri`].
     #[builder(setter(strip_option), default)]
     uri: Option<Cow<'a, str>>,
-    /// The identifier that specifies the group to which the rendition
-    /// belongs.
-    ///
-    /// ### Note
-    ///
-    /// This field is required.
+    /// See [`ExtXMedia::group_id`].
     group_id: Cow<'a, str>,
-    /// The name of the primary language used in the rendition.
-    /// The value has to conform to [`RFC5646`].
-    ///
-    /// ### Note
-    ///
-    /// This field is optional.
-    ///
-    /// [`RFC5646`]: https://tools.ietf.org/html/rfc5646
+    /// See [`ExtXMedia::language`].
     #[builder(setter(strip_option), default)]
     language: Option<Cow<'a, str>>,
-    /// The name of a language associated with the rendition.
-    /// An associated language is often used in a different role, than the
-    /// language specified by the [`language`] field (e.g., written versus
-    /// spoken, or a fallback dialect).
-    ///
-    /// ### Note
-    ///
-    /// This field is optional.
-    ///
-    /// [`language`]: #method.language
+    /// See [`ExtXMedia::assoc_language`].
     #[builder(setter(strip_option), default)]
     assoc_language: Option<Cow<'a, str>>,
-    /// A human-readable description of the rendition.
-    ///
-    /// ### Note
-    ///
-    /// This field is required.
-    ///
-    /// If the [`language`] field is present, this field should be in
-    /// that language.
-    ///
-    /// [`language`]: #method.language
+    /// See [`ExtXMedia::name`].
     name: Cow<'a, str>,
     /// The value of the `default` flag.
     /// A value of `true` indicates, that the client should play
@@ -99,7 +50,6 @@ pub struct ExtXMedia<'a> {
     /// This field is optional, its absence indicates an implicit value
     /// of `false`.
     #[builder(default)]
-    #[shorthand(enable(skip))]
     pub is_default: bool,
     /// Whether the client may choose to play this rendition in the absence of
     /// explicit user preference.
@@ -109,12 +59,10 @@ pub struct ExtXMedia<'a> {
     /// This field is optional, its absence indicates an implicit value
     /// of `false`.
     #[builder(default)]
-    #[shorthand(enable(skip))]
     pub is_autoselect: bool,
     /// Whether the rendition contains content that is considered
     /// essential to play.
     #[builder(default)]
-    #[shorthand(enable(skip))]
     pub is_forced: bool,
     /// An [`InStreamId`] identifies a rendition within the
     /// [`MediaSegment`]s in a [`MediaPlaylist`].
@@ -128,30 +76,8 @@ pub struct ExtXMedia<'a> {
     /// [`MediaPlaylist`]: crate::MediaPlaylist
     /// [`MediaSegment`]: crate::MediaSegment
     #[builder(setter(strip_option), default)]
-    #[shorthand(enable(skip))]
     pub instream_id: Option<InStreamId>,
-    /// The characteristics field contains one or more Uniform Type
-    /// Identifiers ([`UTI`]) separated by a comma.
-    /// Each [`UTI`] indicates an individual characteristic of the Rendition.
-    ///
-    /// An `ExtXMedia` instance with [`MediaType::Subtitles`] may include the
-    /// following characteristics:
-    /// - `"public.accessibility.transcribes-spoken-dialog"`,
-    /// - `"public.accessibility.describes-music-and-sound"`, and
-    /// - `"public.easy-to-read"` (which indicates that the subtitles have been
-    ///   edited for ease of reading).
-    ///
-    /// An `ExtXMedia` instance with [`MediaType::Audio`] may include the
-    /// following characteristic:
-    /// - `"public.accessibility.describes-video"`
-    ///
-    /// The characteristics field may include private UTIs.
-    ///
-    /// ### Note
-    ///
-    /// This field is optional.
-    ///
-    /// [`UTI`]: https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-05#ref-UTI
+    /// See [`ExtXMedia::characteristics`].
     #[builder(setter(strip_option), default)]
     characteristics: Option<Cow<'a, str>>,
     /// A count of audio channels indicating the maximum number of independent,
@@ -168,7 +94,6 @@ pub struct ExtXMedia<'a> {
     /// [`MediaSegment`]: crate::MediaSegment
     /// [`MasterPlaylist`]: crate::MasterPlaylist
     #[builder(setter(strip_option), default)]
-    #[shorthand(enable(skip))]
     pub channels: Option<Channels>,
 }
 
@@ -222,6 +147,141 @@ impl ExtXMediaBuilder<'_> {
 
 impl<'a> ExtXMedia<'a> {
     pub(crate) const PREFIX: &'static str = "#EXT-X-MEDIA:";
+
+    /// An `URI` to a [`MediaPlaylist`].
+    ///
+    /// ### Note
+    ///
+    /// - This field is required, if the [`ExtXMedia::media_type`] is
+    ///   [`MediaType::Subtitles`].
+    /// - This field is not allowed, if the [`ExtXMedia::media_type`] is
+    ///   [`MediaType::ClosedCaptions`].
+    ///
+    /// An absent value indicates that the media data for this rendition is
+    /// included in the [`MediaPlaylist`] of any
+    /// [`VariantStream::ExtXStreamInf`] tag with the same `group_id` of
+    /// this [`ExtXMedia`] instance.
+    ///
+    /// [`MediaPlaylist`]: crate::MediaPlaylist
+    /// [`VariantStream::ExtXStreamInf`]:
+    /// crate::tags::VariantStream::ExtXStreamInf
+    #[must_use]
+    pub fn uri(&self) -> Option<&Cow<'a, str>> {
+        self.uri.as_ref()
+    }
+
+    /// Sets [`ExtXMedia::uri`].
+    pub fn set_uri<V: Into<Cow<'a, str>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.uri = value.map(Into::into);
+        self
+    }
+
+    /// The identifier that specifies the group to which the rendition
+    /// belongs.
+    ///
+    /// ### Note
+    ///
+    /// This field is required.
+    #[must_use]
+    pub fn group_id(&self) -> &Cow<'a, str> {
+        &self.group_id
+    }
+
+    /// Sets [`ExtXMedia::group_id`].
+    pub fn set_group_id<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.group_id = value.into();
+        self
+    }
+
+    /// The name of the primary language used in the rendition.
+    /// The value has to conform to [`RFC5646`].
+    ///
+    /// ### Note
+    ///
+    /// This field is optional.
+    ///
+    /// [`RFC5646`]: https://tools.ietf.org/html/rfc5646
+    #[must_use]
+    pub fn language(&self) -> Option<&Cow<'a, str>> {
+        self.language.as_ref()
+    }
+
+    /// Sets [`ExtXMedia::language`].
+    pub fn set_language<V: Into<Cow<'a, str>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.language = value.map(Into::into);
+        self
+    }
+
+    /// The name of a language associated with the rendition.
+    /// An associated language is often used in a different role, than the
+    /// language specified by the [`ExtXMedia::language`] field (e.g., written
+    /// versus spoken, or a fallback dialect).
+    ///
+    /// ### Note
+    ///
+    /// This field is optional.
+    #[must_use]
+    pub fn assoc_language(&self) -> Option<&Cow<'a, str>> {
+        self.assoc_language.as_ref()
+    }
+
+    /// Sets [`ExtXMedia::assoc_language`].
+    pub fn set_assoc_language<V: Into<Cow<'a, str>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.assoc_language = value.map(Into::into);
+        self
+    }
+
+    /// A human-readable description of the rendition.
+    ///
+    /// ### Note
+    ///
+    /// This field is required.
+    ///
+    /// If the [`ExtXMedia::language`] field is present, this field should be
+    /// in that language.
+    #[must_use]
+    pub fn name(&self) -> &Cow<'a, str> {
+        &self.name
+    }
+
+    /// Sets [`ExtXMedia::name`].
+    pub fn set_name<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.name = value.into();
+        self
+    }
+
+    /// The characteristics field contains one or more Uniform Type
+    /// Identifiers ([`UTI`]) separated by a comma.
+    /// Each [`UTI`] indicates an individual characteristic of the Rendition.
+    ///
+    /// An `ExtXMedia` instance with [`MediaType::Subtitles`] may include the
+    /// following characteristics:
+    /// - `"public.accessibility.transcribes-spoken-dialog"`,
+    /// - `"public.accessibility.describes-music-and-sound"`, and
+    /// - `"public.easy-to-read"` (which indicates that the subtitles have been
+    ///   edited for ease of reading).
+    ///
+    /// An `ExtXMedia` instance with [`MediaType::Audio`] may include the
+    /// following characteristic:
+    /// - `"public.accessibility.describes-video"`
+    ///
+    /// The characteristics field may include private UTIs.
+    ///
+    /// ### Note
+    ///
+    /// This field is optional.
+    ///
+    /// [`UTI`]: https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-05#ref-UTI
+    #[must_use]
+    pub fn characteristics(&self) -> Option<&Cow<'a, str>> {
+        self.characteristics.as_ref()
+    }
+
+    /// Sets [`ExtXMedia::characteristics`].
+    pub fn set_characteristics<V: Into<Cow<'a, str>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.characteristics = value.map(Into::into);
+        self
+    }
 
     /// Makes a new [`ExtXMedia`] tag with the associated [`MediaType`], the
     /// identifier that specifies the group to which the rendition belongs

--- a/src/tags/master_playlist/session_data.rs
+++ b/src/tags/master_playlist/session_data.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt;
 
-use derive_builder::Builder;
-
 use crate::attribute::AttributePairs;
 use crate::types::ProtocolVersion;
 use crate::utils::{quote, tag, unquote};
@@ -46,10 +44,8 @@ impl SessionData<'_> {
 /// Allows arbitrary session data to be carried in a [`MasterPlaylist`].
 ///
 /// [`MasterPlaylist`]: crate::MasterPlaylist
-#[derive(Builder, Hash, Eq, Ord, Debug, PartialEq, Clone, PartialOrd)]
-#[builder(setter(into))]
+#[derive(Hash, Eq, Ord, Debug, PartialEq, Clone, PartialOrd)]
 pub struct ExtXSessionData<'a> {
-    /// See [`ExtXSessionData::data_id`].
     data_id: Cow<'a, str>,
     /// The [`SessionData`] associated with the
     /// [`data_id`](ExtXSessionData::data_id).
@@ -58,9 +54,54 @@ pub struct ExtXSessionData<'a> {
     ///
     /// This field is required.
     pub data: SessionData<'a>,
-    /// See [`ExtXSessionData::language`].
-    #[builder(setter(strip_option), default)]
     language: Option<Cow<'a, str>>,
+}
+
+/// Builder for [`ExtXSessionData`].
+#[derive(Debug, Clone, Default)]
+pub struct ExtXSessionDataBuilder<'a> {
+    data_id: Option<Cow<'a, str>>,
+    data: Option<SessionData<'a>>,
+    language: Option<Cow<'a, str>>,
+}
+
+impl<'a> ExtXSessionDataBuilder<'a> {
+    /// See [`ExtXSessionData::data_id`].
+    pub fn data_id<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.data_id = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXSessionData::data`].
+    pub fn data<V: Into<SessionData<'a>>>(&mut self, value: V) -> &mut Self {
+        self.data = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXSessionData::language`].
+    pub fn language<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.language = Some(value.into());
+        self
+    }
+
+    /// Builds a new [`ExtXSessionData`].
+    ///
+    /// # Errors
+    ///
+    /// If a required field has not been initialized.
+    pub fn build(&self) -> Result<ExtXSessionData<'a>, Error> {
+        Ok(ExtXSessionData {
+            data_id: self
+                .data_id
+                .clone()
+                .ok_or_else(|| Error::missing_field("ExtXSessionData", "data_id"))?,
+            data: self
+                .data
+                .clone()
+                .ok_or_else(|| Error::missing_field("ExtXSessionData", "data"))?,
+            language: self.language.clone(),
+        })
+    }
 }
 
 impl<'a> ExtXSessionData<'a> {

--- a/src/tags/master_playlist/session_data.rs
+++ b/src/tags/master_playlist/session_data.rs
@@ -3,7 +3,6 @@ use std::convert::TryFrom;
 use std::fmt;
 
 use derive_builder::Builder;
-use shorthand::ShortHand;
 
 use crate::attribute::AttributePairs;
 use crate::types::ProtocolVersion;
@@ -47,10 +46,26 @@ impl SessionData<'_> {
 /// Allows arbitrary session data to be carried in a [`MasterPlaylist`].
 ///
 /// [`MasterPlaylist`]: crate::MasterPlaylist
-#[derive(ShortHand, Builder, Hash, Eq, Ord, Debug, PartialEq, Clone, PartialOrd)]
+#[derive(Builder, Hash, Eq, Ord, Debug, PartialEq, Clone, PartialOrd)]
 #[builder(setter(into))]
-#[shorthand(enable(must_use, into))]
 pub struct ExtXSessionData<'a> {
+    /// See [`ExtXSessionData::data_id`].
+    data_id: Cow<'a, str>,
+    /// The [`SessionData`] associated with the
+    /// [`data_id`](ExtXSessionData::data_id).
+    ///
+    /// # Note
+    ///
+    /// This field is required.
+    pub data: SessionData<'a>,
+    /// See [`ExtXSessionData::language`].
+    #[builder(setter(strip_option), default)]
+    language: Option<Cow<'a, str>>,
+}
+
+impl<'a> ExtXSessionData<'a> {
+    pub(crate) const PREFIX: &'static str = "#EXT-X-SESSION-DATA:";
+
     /// This should conform to a [reverse DNS] naming convention, such as
     /// `com.example.movie.title`.
     ///
@@ -62,15 +77,17 @@ pub struct ExtXSessionData<'a> {
     /// This field is required.
     ///
     /// [reverse DNS]: https://en.wikipedia.org/wiki/Reverse_domain_name_notation
-    data_id: Cow<'a, str>,
-    /// The [`SessionData`] associated with the
-    /// [`data_id`](ExtXSessionData::data_id).
-    ///
-    /// # Note
-    ///
-    /// This field is required.
-    #[shorthand(enable(skip))]
-    pub data: SessionData<'a>,
+    #[must_use]
+    pub fn data_id(&self) -> &Cow<'a, str> {
+        &self.data_id
+    }
+
+    /// Sets [`ExtXSessionData::data_id`].
+    pub fn set_data_id<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.data_id = value.into();
+        self
+    }
+
     /// The `language` attribute identifies the language of the [`SessionData`].
     ///
     /// # Note
@@ -79,12 +96,16 @@ pub struct ExtXSessionData<'a> {
     /// [RFC5646].
     ///
     /// [RFC5646]: https://tools.ietf.org/html/rfc5646
-    #[builder(setter(strip_option), default)]
-    language: Option<Cow<'a, str>>,
-}
+    #[must_use]
+    pub fn language(&self) -> Option<&Cow<'a, str>> {
+        self.language.as_ref()
+    }
 
-impl<'a> ExtXSessionData<'a> {
-    pub(crate) const PREFIX: &'static str = "#EXT-X-SESSION-DATA:";
+    /// Sets [`ExtXSessionData::language`].
+    pub fn set_language<V: Into<Cow<'a, str>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.language = value.map(Into::into);
+        self
+    }
 
     /// Makes a new [`ExtXSessionData`] tag.
     ///

--- a/src/tags/master_playlist/variant_stream.rs
+++ b/src/tags/master_playlist/variant_stream.rs
@@ -207,10 +207,10 @@ impl VariantStream<'_> {
     pub fn is_associated(&self, media: &ExtXMedia<'_>) -> bool {
         match &self {
             Self::ExtXIFrame { stream_data, .. } => {
-                if let MediaType::Video = media.media_type {
-                    if let Some(value) = stream_data.video() {
-                        return value == media.group_id();
-                    }
+                if let MediaType::Video = media.media_type
+                    && let Some(value) = stream_data.video()
+                {
+                    return value == media.group_id();
                 }
 
                 false

--- a/src/tags/media_segment/date_range.rs
+++ b/src/tags/media_segment/date_range.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, FixedOffset, SecondsFormat};
 use derive_builder::Builder;
-use shorthand::ShortHand;
 
 use crate::attribute::AttributePairs;
 use crate::types::{ProtocolVersion, Value};
@@ -16,68 +15,27 @@ use crate::{Error, RequiredVersion};
 
 /// The [`ExtXDateRange`] tag associates a date range (i.e., a range of time
 /// defined by a starting and ending date) with a set of attribute/value pairs.
-#[derive(ShortHand, Builder, Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Builder, Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[builder(setter(into))]
-#[shorthand(enable(must_use, into))]
 pub struct ExtXDateRange<'a> {
-    /// A string that uniquely identifies an [`ExtXDateRange`] in the playlist.
-    ///
-    /// ## Note
-    ///
-    /// This field is required.
+    /// See [`ExtXDateRange::id`].
     id: Cow<'a, str>,
-    /// A client-defined string that specifies some set of attributes and their
-    /// associated value semantics. All [`ExtXDateRange`]s with the same class
-    /// attribute value must adhere to these semantics.
-    ///
-    /// ## Note
-    ///
-    /// This field is optional.
+    /// See [`ExtXDateRange::class`].
     #[builder(setter(strip_option), default)]
     class: Option<Cow<'a, str>>,
-    /// The date at which the [`ExtXDateRange`] begins.
-    ///
-    /// ## Note
-    ///
-    /// This field is required by the spec wording, but optional in examples
-    /// elsewhere in the same document.  Some implementations omit it in
-    /// practise (e.g. for SCTE 'explicit-IN' markers) so it is optional
-    /// here.
+    /// See [`ExtXDateRange::start_date`].
     #[cfg(feature = "chrono")]
-    #[shorthand(enable(copy), disable(into))]
     #[builder(setter(strip_option), default)]
     start_date: Option<DateTime<FixedOffset>>,
-    /// The date at which the [`ExtXDateRange`] begins.
-    ///
-    /// ## Note
-    ///
-    /// This field is required by the spec wording, but optional in examples
-    /// elsewhere in the same document.  Some implementations omit it in
-    /// practise (e.g. for SCTE 'explicit-IN' markers) so it is optional
-    /// here.
+    /// See [`ExtXDateRange::start_date`].
     #[cfg(not(feature = "chrono"))]
     #[builder(setter(strip_option), default)]
     start_date: Option<Cow<'a, str>>,
-    /// The date at which the [`ExtXDateRange`] ends. It must be equal to or
-    /// later than the value of the [`start-date`] attribute.
-    ///
-    /// ## Note
-    ///
-    /// This field is optional.
-    ///
-    /// [`start-date`]: #method.start_date
+    /// See [`ExtXDateRange::end_date`].
     #[cfg(feature = "chrono")]
-    #[shorthand(enable(copy), disable(into))]
     #[builder(setter(strip_option), default)]
     end_date: Option<DateTime<FixedOffset>>,
-    /// The date at which the [`ExtXDateRange`] ends. It must be equal to or
-    /// later than the value of the start-date field.
-    ///
-    /// ## Note
-    ///
-    /// This field is optional.
-    ///
-    /// [`start-date`]: #method.start_date
+    /// See [`ExtXDateRange::end_date`].
     #[cfg(not(feature = "chrono"))]
     #[builder(setter(strip_option), default)]
     end_date: Option<Cow<'a, str>>,
@@ -88,7 +46,6 @@ pub struct ExtXDateRange<'a> {
     ///
     /// This field is optional.
     #[builder(setter(strip_option), default)]
-    #[shorthand(enable(skip))]
     pub duration: Option<Duration>,
     /// This field indicates the expected duration of an [`ExtXDateRange`],
     /// whose actual duration is not yet known.
@@ -97,57 +54,14 @@ pub struct ExtXDateRange<'a> {
     ///
     /// This field is optional.
     #[builder(setter(strip_option), default)]
-    #[shorthand(enable(skip))]
     pub planned_duration: Option<Duration>,
-    /// SCTE-35 (ANSI/SCTE 35 2013) is a joint ANSI/Society of Cable and
-    /// Telecommunications Engineers standard that describes the inline
-    /// insertion of cue tones in mpeg-ts streams.
-    ///
-    /// SCTE-35 was originally used in the US to signal a local ad insertion
-    /// opportunity in the transport streams, and in Europe to insert local TV
-    /// programs (e.g. local news transmissions). It is now used to signal all
-    /// kinds of program and ad events in linear transport streams and in newer
-    /// ABR delivery formats such as HLS and DASH.
-    ///
-    /// <https://en.wikipedia.org/wiki/SCTE-35>
-    ///
-    /// ## Note
-    ///
-    /// This field is optional.
+    /// See [`ExtXDateRange::scte35_cmd`].
     #[builder(setter(strip_option), default)]
     scte35_cmd: Option<Cow<'a, str>>,
-    /// SCTE-35 (ANSI/SCTE 35 2013) is a joint ANSI/Society of Cable and
-    /// Telecommunications Engineers standard that describes the inline
-    /// insertion of cue tones in mpeg-ts streams.
-    ///
-    /// SCTE-35 was originally used in the US to signal a local ad insertion
-    /// opportunity in the transport streams, and in Europe to insert local TV
-    /// programs (e.g. local news transmissions). It is now used to signal all
-    /// kinds of program and ad events in linear transport streams and in newer
-    /// ABR delivery formats such as HLS and DASH.
-    ///
-    /// <https://en.wikipedia.org/wiki/SCTE-35>
-    ///
-    /// ## Note
-    ///
-    /// This field is optional.
+    /// See [`ExtXDateRange::scte35_out`].
     #[builder(setter(strip_option), default)]
     scte35_out: Option<Cow<'a, str>>,
-    /// SCTE-35 (ANSI/SCTE 35 2013) is a joint ANSI/Society of Cable and
-    /// Telecommunications Engineers standard that describes the inline
-    /// insertion of cue tones in mpeg-ts streams.
-    ///
-    /// SCTE-35 was originally used in the US to signal a local ad insertion
-    /// opportunity in the transport streams, and in Europe to insert local TV
-    /// programs (e.g. local news transmissions). It is now used to signal all
-    /// kinds of program and ad events in linear transport streams and in newer
-    /// ABR delivery formats such as HLS and DASH.
-    ///
-    /// <https://en.wikipedia.org/wiki/SCTE-35>
-    ///
-    /// ## Note
-    ///
-    /// This field is optional.
+    /// See [`ExtXDateRange::scte35_in`].
     #[builder(setter(strip_option), default)]
     scte35_in: Option<Cow<'a, str>>,
     /// This field indicates that the [`ExtXDateRange::end_date`] is equal to
@@ -161,7 +75,6 @@ pub struct ExtXDateRange<'a> {
     ///
     /// This field is optional.
     #[builder(default)]
-    #[shorthand(enable(skip))]
     pub end_on_next: bool,
     /// The `"X-"` prefix defines a namespace reserved for client-defined
     /// attributes.
@@ -179,7 +92,6 @@ pub struct ExtXDateRange<'a> {
     ///
     /// This field is optional.
     #[builder(default)]
-    #[shorthand(enable(collection_magic), disable(set, get))]
     pub client_attributes: BTreeMap<Cow<'a, str>, Value<'a>>,
 }
 
@@ -200,6 +112,174 @@ impl<'a> ExtXDateRangeBuilder<'a> {
 
 impl<'a> ExtXDateRange<'a> {
     pub(crate) const PREFIX: &'static str = "#EXT-X-DATERANGE:";
+
+    /// A string that uniquely identifies an [`ExtXDateRange`] in the playlist.
+    ///
+    /// ## Note
+    ///
+    /// This field is required.
+    #[must_use]
+    pub fn id(&self) -> &Cow<'a, str> {
+        &self.id
+    }
+
+    /// Sets [`ExtXDateRange::id`].
+    pub fn set_id<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.id = value.into();
+        self
+    }
+
+    /// A client-defined string that specifies some set of attributes and their
+    /// associated value semantics. All [`ExtXDateRange`]s with the same class
+    /// attribute value must adhere to these semantics.
+    ///
+    /// ## Note
+    ///
+    /// This field is optional.
+    #[must_use]
+    pub fn class(&self) -> Option<&Cow<'a, str>> {
+        self.class.as_ref()
+    }
+
+    /// Sets [`ExtXDateRange::class`].
+    pub fn set_class<V: Into<Cow<'a, str>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.class = value.map(Into::into);
+        self
+    }
+
+    /// The date at which the [`ExtXDateRange`] begins.
+    ///
+    /// ## Note
+    ///
+    /// This field is required by the spec wording, but optional in examples
+    /// elsewhere in the same document.  Some implementations omit it in
+    /// practise (e.g. for SCTE 'explicit-IN' markers) so it is optional
+    /// here.
+    #[cfg(feature = "chrono")]
+    #[must_use]
+    pub fn start_date(&self) -> Option<DateTime<FixedOffset>> {
+        self.start_date
+    }
+
+    /// Sets [`ExtXDateRange::start_date`].
+    #[cfg(feature = "chrono")]
+    pub fn set_start_date(&mut self, value: Option<DateTime<FixedOffset>>) -> &mut Self {
+        self.start_date = value;
+        self
+    }
+
+    /// The date at which the [`ExtXDateRange`] begins.
+    ///
+    /// ## Note
+    ///
+    /// This field is required by the spec wording, but optional in examples
+    /// elsewhere in the same document.  Some implementations omit it in
+    /// practise (e.g. for SCTE 'explicit-IN' markers) so it is optional
+    /// here.
+    #[cfg(not(feature = "chrono"))]
+    #[must_use]
+    pub fn start_date(&self) -> Option<&Cow<'a, str>> {
+        self.start_date.as_ref()
+    }
+
+    /// Sets [`ExtXDateRange::start_date`].
+    #[cfg(not(feature = "chrono"))]
+    pub fn set_start_date<V: Into<Cow<'a, str>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.start_date = value.map(Into::into);
+        self
+    }
+
+    /// The date at which the [`ExtXDateRange`] ends. It must be equal to or
+    /// later than the value of the [`ExtXDateRange::start_date`] attribute.
+    ///
+    /// ## Note
+    ///
+    /// This field is optional.
+    #[cfg(feature = "chrono")]
+    #[must_use]
+    pub fn end_date(&self) -> Option<DateTime<FixedOffset>> {
+        self.end_date
+    }
+
+    /// Sets [`ExtXDateRange::end_date`].
+    #[cfg(feature = "chrono")]
+    pub fn set_end_date(&mut self, value: Option<DateTime<FixedOffset>>) -> &mut Self {
+        self.end_date = value;
+        self
+    }
+
+    /// The date at which the [`ExtXDateRange`] ends. It must be equal to or
+    /// later than the value of the [`ExtXDateRange::start_date`] attribute.
+    ///
+    /// ## Note
+    ///
+    /// This field is optional.
+    #[cfg(not(feature = "chrono"))]
+    #[must_use]
+    pub fn end_date(&self) -> Option<&Cow<'a, str>> {
+        self.end_date.as_ref()
+    }
+
+    /// Sets [`ExtXDateRange::end_date`].
+    #[cfg(not(feature = "chrono"))]
+    pub fn set_end_date<V: Into<Cow<'a, str>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.end_date = value.map(Into::into);
+        self
+    }
+
+    /// SCTE-35 (ANSI/SCTE 35 2013) is a joint ANSI/Society of Cable and
+    /// Telecommunications Engineers standard that describes the inline
+    /// insertion of cue tones in mpeg-ts streams.
+    ///
+    /// <https://en.wikipedia.org/wiki/SCTE-35>
+    ///
+    /// ## Note
+    ///
+    /// This field is optional.
+    #[must_use]
+    pub fn scte35_cmd(&self) -> Option<&Cow<'a, str>> {
+        self.scte35_cmd.as_ref()
+    }
+
+    /// Sets [`ExtXDateRange::scte35_cmd`].
+    pub fn set_scte35_cmd<V: Into<Cow<'a, str>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.scte35_cmd = value.map(Into::into);
+        self
+    }
+
+    /// See [`ExtXDateRange::scte35_cmd`].
+    #[must_use]
+    pub fn scte35_out(&self) -> Option<&Cow<'a, str>> {
+        self.scte35_out.as_ref()
+    }
+
+    /// Sets [`ExtXDateRange::scte35_out`].
+    pub fn set_scte35_out<V: Into<Cow<'a, str>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.scte35_out = value.map(Into::into);
+        self
+    }
+
+    /// See [`ExtXDateRange::scte35_cmd`].
+    #[must_use]
+    pub fn scte35_in(&self) -> Option<&Cow<'a, str>> {
+        self.scte35_in.as_ref()
+    }
+
+    /// Sets [`ExtXDateRange::scte35_in`].
+    pub fn set_scte35_in<V: Into<Cow<'a, str>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.scte35_in = value.map(Into::into);
+        self
+    }
+
+    /// Inserts a key/value pair into [`ExtXDateRange::client_attributes`].
+    pub fn insert_client_attributes<K: Into<Cow<'a, str>>, V: Into<Value<'a>>>(
+        &mut self,
+        key: K,
+        value: V,
+    ) -> &mut Self {
+        self.client_attributes.insert(key.into(), value.into());
+        self
+    }
 
     /// Makes a new [`ExtXDateRange`] tag.
     ///

--- a/src/tags/media_segment/date_range.rs
+++ b/src/tags/media_segment/date_range.rs
@@ -540,12 +540,11 @@ impl<'a> TryFrom<&'a str> for ExtXDateRange<'a> {
                 start_date,
                 duration.map(chrono::Duration::from_std),
                 &end_date,
-            ) {
-                if start_date + duration != *end_date {
-                    return Err(Error::custom(
-                        "end_date must be equal to start_date + duration",
-                    ));
-                }
+            ) && start_date + duration != *end_date
+            {
+                return Err(Error::custom(
+                    "end_date must be equal to start_date + duration",
+                ));
             }
         }
 

--- a/src/tags/media_segment/date_range.rs
+++ b/src/tags/media_segment/date_range.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, FixedOffset, SecondsFormat};
-use derive_builder::Builder;
 
 use crate::attribute::AttributePairs;
 use crate::types::{ProtocolVersion, Value};
@@ -15,29 +14,17 @@ use crate::{Error, RequiredVersion};
 
 /// The [`ExtXDateRange`] tag associates a date range (i.e., a range of time
 /// defined by a starting and ending date) with a set of attribute/value pairs.
-#[derive(Builder, Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
-#[builder(setter(into))]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ExtXDateRange<'a> {
-    /// See [`ExtXDateRange::id`].
     id: Cow<'a, str>,
-    /// See [`ExtXDateRange::class`].
-    #[builder(setter(strip_option), default)]
     class: Option<Cow<'a, str>>,
-    /// See [`ExtXDateRange::start_date`].
     #[cfg(feature = "chrono")]
-    #[builder(setter(strip_option), default)]
     start_date: Option<DateTime<FixedOffset>>,
-    /// See [`ExtXDateRange::start_date`].
     #[cfg(not(feature = "chrono"))]
-    #[builder(setter(strip_option), default)]
     start_date: Option<Cow<'a, str>>,
-    /// See [`ExtXDateRange::end_date`].
     #[cfg(feature = "chrono")]
-    #[builder(setter(strip_option), default)]
     end_date: Option<DateTime<FixedOffset>>,
-    /// See [`ExtXDateRange::end_date`].
     #[cfg(not(feature = "chrono"))]
-    #[builder(setter(strip_option), default)]
     end_date: Option<Cow<'a, str>>,
     /// The duration of the [`ExtXDateRange`]. A single instant in time (e.g.,
     /// crossing a finish line) should be represented with a duration of 0.
@@ -45,7 +32,6 @@ pub struct ExtXDateRange<'a> {
     /// ## Note
     ///
     /// This field is optional.
-    #[builder(setter(strip_option), default)]
     pub duration: Option<Duration>,
     /// This field indicates the expected duration of an [`ExtXDateRange`],
     /// whose actual duration is not yet known.
@@ -53,16 +39,9 @@ pub struct ExtXDateRange<'a> {
     /// ## Note
     ///
     /// This field is optional.
-    #[builder(setter(strip_option), default)]
     pub planned_duration: Option<Duration>,
-    /// See [`ExtXDateRange::scte35_cmd`].
-    #[builder(setter(strip_option), default)]
     scte35_cmd: Option<Cow<'a, str>>,
-    /// See [`ExtXDateRange::scte35_out`].
-    #[builder(setter(strip_option), default)]
     scte35_out: Option<Cow<'a, str>>,
-    /// See [`ExtXDateRange::scte35_in`].
-    #[builder(setter(strip_option), default)]
     scte35_in: Option<Cow<'a, str>>,
     /// This field indicates that the [`ExtXDateRange::end_date`] is equal to
     /// the [`ExtXDateRange::start_date`] of the following range.
@@ -74,7 +53,6 @@ pub struct ExtXDateRange<'a> {
     /// ## Note
     ///
     /// This field is optional.
-    #[builder(default)]
     pub end_on_next: bool,
     /// The `"X-"` prefix defines a namespace reserved for client-defined
     /// attributes.
@@ -91,22 +69,152 @@ pub struct ExtXDateRange<'a> {
     /// ## Note
     ///
     /// This field is optional.
-    #[builder(default)]
     pub client_attributes: BTreeMap<Cow<'a, str>, Value<'a>>,
 }
 
+/// Builder for [`ExtXDateRange`].
+#[derive(Debug, Clone, Default)]
+pub struct ExtXDateRangeBuilder<'a> {
+    id: Option<Cow<'a, str>>,
+    class: Option<Cow<'a, str>>,
+    #[cfg(feature = "chrono")]
+    start_date: Option<DateTime<FixedOffset>>,
+    #[cfg(not(feature = "chrono"))]
+    start_date: Option<Cow<'a, str>>,
+    #[cfg(feature = "chrono")]
+    end_date: Option<DateTime<FixedOffset>>,
+    #[cfg(not(feature = "chrono"))]
+    end_date: Option<Cow<'a, str>>,
+    duration: Option<Duration>,
+    planned_duration: Option<Duration>,
+    scte35_cmd: Option<Cow<'a, str>>,
+    scte35_out: Option<Cow<'a, str>>,
+    scte35_in: Option<Cow<'a, str>>,
+    end_on_next: Option<bool>,
+    client_attributes: BTreeMap<Cow<'a, str>, Value<'a>>,
+}
+
 impl<'a> ExtXDateRangeBuilder<'a> {
+    /// See [`ExtXDateRange::id`].
+    pub fn id<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.id = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXDateRange::class`].
+    pub fn class<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.class = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXDateRange::start_date`].
+    #[cfg(feature = "chrono")]
+    pub fn start_date(&mut self, value: DateTime<FixedOffset>) -> &mut Self {
+        self.start_date = Some(value);
+        self
+    }
+
+    /// See [`ExtXDateRange::start_date`].
+    #[cfg(not(feature = "chrono"))]
+    pub fn start_date<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.start_date = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXDateRange::end_date`].
+    #[cfg(feature = "chrono")]
+    pub fn end_date(&mut self, value: DateTime<FixedOffset>) -> &mut Self {
+        self.end_date = Some(value);
+        self
+    }
+
+    /// See [`ExtXDateRange::end_date`].
+    #[cfg(not(feature = "chrono"))]
+    pub fn end_date<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.end_date = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXDateRange::duration`].
+    pub fn duration(&mut self, value: Duration) -> &mut Self {
+        self.duration = Some(value);
+        self
+    }
+
+    /// See [`ExtXDateRange::planned_duration`].
+    pub fn planned_duration(&mut self, value: Duration) -> &mut Self {
+        self.planned_duration = Some(value);
+        self
+    }
+
+    /// See [`ExtXDateRange::scte35_cmd`].
+    pub fn scte35_cmd<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.scte35_cmd = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXDateRange::scte35_out`].
+    pub fn scte35_out<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.scte35_out = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXDateRange::scte35_in`].
+    pub fn scte35_in<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.scte35_in = Some(value.into());
+        self
+    }
+
+    /// See [`ExtXDateRange::end_on_next`].
+    pub fn end_on_next(&mut self, value: bool) -> &mut Self {
+        self.end_on_next = Some(value);
+        self
+    }
+
+    /// See [`ExtXDateRange::client_attributes`].
+    pub fn client_attributes(&mut self, value: BTreeMap<Cow<'a, str>, Value<'a>>) -> &mut Self {
+        self.client_attributes = value;
+        self
+    }
+
     /// Inserts a key value pair.
     pub fn insert_client_attribute<K: Into<Cow<'a, str>>, V: Into<Value<'a>>>(
         &mut self,
         key: K,
         value: V,
     ) -> &mut Self {
-        let attrs = self.client_attributes.get_or_insert_with(BTreeMap::new);
-
-        attrs.insert(key.into(), value.into());
-
+        self.client_attributes.insert(key.into(), value.into());
         self
+    }
+
+    /// Builds a new [`ExtXDateRange`].
+    ///
+    /// # Errors
+    ///
+    /// If a required field has not been initialized.
+    pub fn build(&self) -> Result<ExtXDateRange<'a>, Error> {
+        Ok(ExtXDateRange {
+            id: self
+                .id
+                .clone()
+                .ok_or_else(|| Error::missing_field("ExtXDateRange", "id"))?,
+            class: self.class.clone(),
+            #[cfg(feature = "chrono")]
+            start_date: self.start_date,
+            #[cfg(not(feature = "chrono"))]
+            start_date: self.start_date.clone(),
+            #[cfg(feature = "chrono")]
+            end_date: self.end_date,
+            #[cfg(not(feature = "chrono"))]
+            end_date: self.end_date.clone(),
+            duration: self.duration,
+            planned_duration: self.planned_duration,
+            scte35_cmd: self.scte35_cmd.clone(),
+            scte35_out: self.scte35_out.clone(),
+            scte35_in: self.scte35_in.clone(),
+            end_on_next: self.end_on_next.unwrap_or(false),
+            client_attributes: self.client_attributes.clone(),
+        })
     }
 }
 

--- a/src/tags/media_segment/map.rs
+++ b/src/tags/media_segment/map.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 
-use shorthand::ShortHand;
-
 use crate::attribute::AttributePairs;
 use crate::tags::ExtXKey;
 use crate::types::{ByteRange, DecryptionKey, ProtocolVersion};
@@ -32,21 +30,40 @@ use crate::{Decryptable, Error, RequiredVersion};
 /// [`ExtXDiscontinuity`]: crate::tags::ExtXDiscontinuity
 /// [`EncryptionMethod::Aes128`]: crate::types::EncryptionMethod::Aes128
 /// [`MediaPlaylist`]: crate::MediaPlaylist
-#[derive(ShortHand, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[shorthand(enable(must_use, into))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ExtXMap<'a> {
-    /// The `URI` that identifies a resource, that contains the media
-    /// initialization section.
     uri: Cow<'a, str>,
-    /// The range of the media initialization section.
-    #[shorthand(enable(copy))]
     range: Option<ByteRange>,
-    #[shorthand(enable(skip))]
     pub(crate) keys: Vec<ExtXKey<'a>>,
 }
 
 impl<'a> ExtXMap<'a> {
     pub(crate) const PREFIX: &'static str = "#EXT-X-MAP:";
+
+    /// The `URI` that identifies a resource, that contains the media
+    /// initialization section.
+    #[must_use]
+    pub fn uri(&self) -> &Cow<'a, str> {
+        &self.uri
+    }
+
+    /// Sets [`ExtXMap::uri`].
+    pub fn set_uri<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.uri = value.into();
+        self
+    }
+
+    /// The range of the media initialization section.
+    #[must_use]
+    pub fn range(&self) -> Option<ByteRange> {
+        self.range
+    }
+
+    /// Sets [`ExtXMap::range`].
+    pub fn set_range<V: Into<ByteRange>>(&mut self, value: Option<V>) -> &mut Self {
+        self.range = value.map(Into::into);
+        self
+    }
 
     /// Makes a new [`ExtXMap`] tag.
     ///

--- a/src/tags/shared/start.rs
+++ b/src/tags/shared/start.rs
@@ -1,8 +1,6 @@
 use std::convert::TryFrom;
 use std::fmt;
 
-use shorthand::ShortHand;
-
 use crate::attribute::AttributePairs;
 use crate::types::{Float, ProtocolVersion};
 use crate::utils::{parse_yes_or_no, tag};
@@ -13,9 +11,15 @@ use crate::{Error, RequiredVersion};
 ///
 /// By default, clients should start playback at this point when beginning a
 /// playback session.
-#[derive(ShortHand, PartialOrd, Debug, Clone, Copy, PartialEq, Eq, Ord, Hash)]
-#[shorthand(enable(must_use))]
+#[derive(PartialOrd, Debug, Clone, Copy, PartialEq, Eq, Ord, Hash)]
 pub struct ExtXStart {
+    time_offset: Float,
+    is_precise: bool,
+}
+
+impl ExtXStart {
+    pub(crate) const PREFIX: &'static str = "#EXT-X-START:";
+
     /// The time offset of the [`MediaSegment`]s in the playlist.
     ///
     /// # Example
@@ -32,8 +36,17 @@ pub struct ExtXStart {
     /// ```
     ///
     /// [`MediaSegment`]: crate::MediaSegment
-    #[shorthand(enable(copy))]
-    time_offset: Float,
+    #[must_use]
+    pub fn time_offset(&self) -> Float {
+        self.time_offset
+    }
+
+    /// Sets [`ExtXStart::time_offset`].
+    pub fn set_time_offset(&mut self, value: Float) -> &mut Self {
+        self.time_offset = value;
+        self
+    }
+
     /// Whether clients should not render media stream whose presentation times
     /// are prior to the specified time offset.
     ///
@@ -49,11 +62,16 @@ pub struct ExtXStart {
     ///
     /// assert_eq!(start.is_precise(), true);
     /// ```
-    is_precise: bool,
-}
+    #[must_use]
+    pub fn is_precise(&self) -> bool {
+        self.is_precise
+    }
 
-impl ExtXStart {
-    pub(crate) const PREFIX: &'static str = "#EXT-X-START:";
+    /// Sets [`ExtXStart::is_precise`].
+    pub fn set_is_precise(&mut self, value: bool) -> &mut Self {
+        self.is_precise = value;
+        self
+    }
 
     /// Makes a new [`ExtXStart`] tag.
     ///

--- a/src/types/byte_range.rs
+++ b/src/types/byte_range.rs
@@ -6,8 +6,6 @@ use core::ops::{
 };
 use std::borrow::Cow;
 
-use shorthand::ShortHand;
-
 use crate::Error;
 
 /// A range of bytes, which can be seen as either `..end` or `start..end`.
@@ -20,9 +18,13 @@ use crate::Error;
 /// let range = ByteRange::from(10..20);
 /// let range = ByteRange::from(..20);
 /// ```
-#[derive(ShortHand, Copy, Hash, Eq, Ord, Debug, PartialEq, Clone, PartialOrd)]
-#[shorthand(enable(must_use, copy), disable(option_as_ref, set))]
+#[derive(Copy, Hash, Eq, Ord, Debug, PartialEq, Clone, PartialOrd)]
 pub struct ByteRange {
+    start: Option<usize>,
+    end: usize,
+}
+
+impl ByteRange {
     /// Returns the `start` of the [`ByteRange`], if there is one.
     ///
     /// # Example
@@ -32,7 +34,11 @@ pub struct ByteRange {
     /// assert_eq!(ByteRange::from(0..5).start(), Some(0));
     /// assert_eq!(ByteRange::from(..5).start(), None);
     /// ```
-    start: Option<usize>,
+    #[must_use]
+    pub fn start(&self) -> Option<usize> {
+        self.start
+    }
+
     /// Returns the `end` of the [`ByteRange`].
     ///
     /// # Example
@@ -42,10 +48,11 @@ pub struct ByteRange {
     /// assert_eq!(ByteRange::from(0..5).end(), 5);
     /// assert_eq!(ByteRange::from(..=5).end(), 6);
     /// ```
-    end: usize,
-}
+    #[must_use]
+    pub fn end(&self) -> usize {
+        self.end
+    }
 
-impl ByteRange {
     /// Changes the length of the [`ByteRange`].
     ///
     /// # Example

--- a/src/types/channels.rs
+++ b/src/types/channels.rs
@@ -1,8 +1,6 @@
 use core::fmt;
 use core::str::FromStr;
 
-use shorthand::ShortHand;
-
 use crate::Error;
 
 /// The maximum number of independent, simultaneous audio channels present in
@@ -12,9 +10,13 @@ use crate::Error;
 /// 6.
 ///
 /// [`MediaSegment`]: crate::MediaSegment
-#[derive(ShortHand, Debug, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[shorthand(enable(must_use))]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Channels {
+    number: u64,
+    mix_type: Option<MixType>,
+}
+
+impl Channels {
     /// The maximum number of independent simultaneous audio channels.
     ///
     /// # Example
@@ -27,7 +29,16 @@ pub struct Channels {
     /// channels.set_number(5);
     /// assert_eq!(channels.number(), 5);
     /// ```
-    number: u64,
+    #[must_use]
+    pub fn number(&self) -> u64 {
+        self.number
+    }
+
+    /// Sets [`Channels::number`].
+    pub fn set_number(&mut self, value: u64) -> &mut Self {
+        self.number = value;
+        self
+    }
 
     /// Dolby Atmos mix type.
     ///
@@ -41,7 +52,16 @@ pub struct Channels {
     /// channels.set_mix_type(Some(MixType::Joc));
     /// assert_eq!(channels.mix_type(), Some(&MixType::Joc));
     /// ```
-    mix_type: Option<MixType>,
+    #[must_use]
+    pub fn mix_type(&self) -> Option<&MixType> {
+        self.mix_type.as_ref()
+    }
+
+    /// Sets [`Channels::mix_type`].
+    pub fn set_mix_type(&mut self, value: Option<MixType>) -> &mut Self {
+        self.mix_type = value;
+        self
+    }
 }
 
 /// Dolby atmos mix type for a [`Channels`] configuration

--- a/src/types/decryption_key.rs
+++ b/src/types/decryption_key.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt;
 
-use derive_builder::Builder;
-
 use crate::attribute::AttributePairs;
 use crate::types::{
     EncryptionMethod, InitializationVector, KeyFormat, KeyFormatVersions, ProtocolVersion,
@@ -12,8 +10,7 @@ use crate::utils::{quote, unquote};
 use crate::{Error, RequiredVersion};
 
 /// Specifies how to decrypt encrypted data from the server.
-#[derive(Builder, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[builder(setter(into), build_fn(validate = "Self::validate"))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[non_exhaustive]
 pub struct DecryptionKey<'a> {
     /// The encryption method, which has been used to encrypt the data.
@@ -42,7 +39,6 @@ pub struct DecryptionKey<'a> {
     /// ## Note
     ///
     /// This field is required.
-    #[builder(setter(into, strip_option), default)]
     pub(crate) uri: Cow<'a, str>,
     /// An initialization vector (IV) is a fixed size input that can be used
     /// along with a secret key for data encryption.
@@ -53,7 +49,6 @@ pub struct DecryptionKey<'a> {
     /// [`MediaSegment::number`] should be used instead.
     ///
     /// [`MediaSegment::number`]: crate::MediaSegment::number
-    #[builder(setter(into, strip_option), default)]
     pub iv: InitializationVector,
     /// A server may offer multiple ways to retrieve a key by providing multiple
     /// [`DecryptionKey`]s with different [`KeyFormat`] values.
@@ -65,7 +60,6 @@ pub struct DecryptionKey<'a> {
     /// ## Note
     ///
     /// This field is optional.
-    #[builder(setter(into, strip_option), default)]
     pub format: Option<KeyFormat<'a>>,
     /// A list of numbers that can be used to indicate which version(s)
     /// this instance complies with, if more than one version of a particular
@@ -74,8 +68,69 @@ pub struct DecryptionKey<'a> {
     /// ## Note
     ///
     /// This field is optional.
-    #[builder(setter(into, strip_option), default)]
     pub versions: Option<KeyFormatVersions>,
+}
+
+/// Builder for [`DecryptionKey`].
+#[derive(Debug, Clone, Default)]
+pub struct DecryptionKeyBuilder<'a> {
+    method: Option<EncryptionMethod>,
+    uri: Option<Cow<'a, str>>,
+    iv: Option<InitializationVector>,
+    format: Option<KeyFormat<'a>>,
+    versions: Option<KeyFormatVersions>,
+}
+
+impl<'a> DecryptionKeyBuilder<'a> {
+    /// See [`DecryptionKey::method`].
+    pub fn method<V: Into<EncryptionMethod>>(&mut self, value: V) -> &mut Self {
+        self.method = Some(value.into());
+        self
+    }
+
+    /// See [`DecryptionKey::uri`].
+    pub fn uri<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.uri = Some(value.into());
+        self
+    }
+
+    /// See [`DecryptionKey::iv`].
+    pub fn iv<V: Into<InitializationVector>>(&mut self, value: V) -> &mut Self {
+        self.iv = Some(value.into());
+        self
+    }
+
+    /// See [`DecryptionKey::format`].
+    pub fn format<V: Into<KeyFormat<'a>>>(&mut self, value: V) -> &mut Self {
+        self.format = Some(value.into());
+        self
+    }
+
+    /// See [`DecryptionKey::versions`].
+    pub fn versions<V: Into<KeyFormatVersions>>(&mut self, value: V) -> &mut Self {
+        self.versions = Some(value.into());
+        self
+    }
+
+    /// Builds a new [`DecryptionKey`].
+    ///
+    /// # Errors
+    ///
+    /// If a required field has not been initialized.
+    pub fn build(&self) -> Result<DecryptionKey<'a>, Error> {
+        Ok(DecryptionKey {
+            method: self
+                .method
+                .ok_or_else(|| Error::missing_field("DecryptionKey", "method"))?,
+            uri: self
+                .uri
+                .clone()
+                .ok_or_else(|| Error::missing_field("DecryptionKey", "uri"))?,
+            iv: self.iv.unwrap_or_default(),
+            format: self.format.clone(),
+            versions: self.versions,
+        })
+    }
 }
 
 impl<'a> DecryptionKey<'a> {
@@ -239,19 +294,6 @@ impl fmt::Display for DecryptionKey<'_> {
             && !value.is_default()
         {
             write!(f, ",KEYFORMATVERSIONS={}", value)?;
-        }
-
-        Ok(())
-    }
-}
-
-impl DecryptionKeyBuilder<'_> {
-    fn validate(&self) -> Result<(), String> {
-        // a decryption key must contain a uri and a method
-        if self.method.is_none() {
-            return Err(Error::missing_field("DecryptionKey", "method").to_string());
-        } else if self.uri.is_none() {
-            return Err(Error::missing_field("DecryptionKey", "uri").to_string());
         }
 
         Ok(())

--- a/src/types/decryption_key.rs
+++ b/src/types/decryption_key.rs
@@ -235,10 +235,10 @@ impl fmt::Display for DecryptionKey<'_> {
             write!(f, ",KEYFORMAT={}", quote(value))?;
         }
 
-        if let Some(value) = &self.versions {
-            if !value.is_default() {
-                write!(f, ",KEYFORMATVERSIONS={}", value)?;
-            }
+        if let Some(value) = &self.versions
+            && !value.is_default()
+        {
+            write!(f, ",KEYFORMATVERSIONS={}", value)?;
         }
 
         Ok(())

--- a/src/types/decryption_key.rs
+++ b/src/types/decryption_key.rs
@@ -3,7 +3,6 @@ use std::convert::TryFrom;
 use std::fmt;
 
 use derive_builder::Builder;
-use shorthand::ShortHand;
 
 use crate::attribute::AttributePairs;
 use crate::types::{
@@ -13,9 +12,8 @@ use crate::utils::{quote, unquote};
 use crate::{Error, RequiredVersion};
 
 /// Specifies how to decrypt encrypted data from the server.
-#[derive(ShortHand, Builder, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Builder, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[builder(setter(into), build_fn(validate = "Self::validate"))]
-#[shorthand(enable(skip, must_use, into))]
 #[non_exhaustive]
 pub struct DecryptionKey<'a> {
     /// The encryption method, which has been used to encrypt the data.
@@ -45,7 +43,6 @@ pub struct DecryptionKey<'a> {
     ///
     /// This field is required.
     #[builder(setter(into, strip_option), default)]
-    #[shorthand(disable(skip))]
     pub(crate) uri: Cow<'a, str>,
     /// An initialization vector (IV) is a fixed size input that can be used
     /// along with a secret key for data encryption.
@@ -103,6 +100,22 @@ impl<'a> DecryptionKey<'a> {
             format: None,
             versions: None,
         }
+    }
+
+    /// This uri points to a key file, which contains the cipher key.
+    ///
+    /// ## Note
+    ///
+    /// This field is required.
+    #[must_use]
+    pub fn uri(&self) -> &Cow<'a, str> {
+        &self.uri
+    }
+
+    /// Sets [`DecryptionKey::uri`].
+    pub fn set_uri<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.uri = value.into();
+        self
     }
 
     /// Returns a builder for a `DecryptionKey`.

--- a/src/types/resolution.rs
+++ b/src/types/resolution.rs
@@ -1,40 +1,15 @@
 use std::fmt;
 use std::str::FromStr;
 
-use shorthand::ShortHand;
-
 use crate::Error;
 
 /// The number of distinct pixels in each dimension that can be displayed (e.g.
 /// 1920x1080).
 ///
 /// For example Full HD has a resolution of 1920x1080.
-#[derive(ShortHand, Ord, PartialOrd, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[shorthand(enable(must_use))]
+#[derive(Ord, PartialOrd, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Resolution {
-    /// Horizontal pixel dimension.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use hls_m3u8::types::Resolution;
-    /// let mut resolution = Resolution::new(1280, 720);
-    ///
-    /// resolution.set_width(1000);
-    /// assert_eq!(resolution.width(), 1000);
-    /// ```
     width: usize,
-    /// Vertical pixel dimension.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use hls_m3u8::types::Resolution;
-    /// let mut resolution = Resolution::new(1280, 720);
-    ///
-    /// resolution.set_height(800);
-    /// assert_eq!(resolution.height(), 800);
-    /// ```
     height: usize,
 }
 
@@ -50,6 +25,50 @@ impl Resolution {
     #[must_use]
     pub const fn new(width: usize, height: usize) -> Self {
         Self { width, height }
+    }
+
+    /// Horizontal pixel dimension.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use hls_m3u8::types::Resolution;
+    /// let mut resolution = Resolution::new(1280, 720);
+    ///
+    /// resolution.set_width(1000);
+    /// assert_eq!(resolution.width(), 1000);
+    /// ```
+    #[must_use]
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    /// Sets [`Resolution::width`].
+    pub fn set_width(&mut self, value: usize) -> &mut Self {
+        self.width = value;
+        self
+    }
+
+    /// Vertical pixel dimension.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use hls_m3u8::types::Resolution;
+    /// let mut resolution = Resolution::new(1280, 720);
+    ///
+    /// resolution.set_height(800);
+    /// assert_eq!(resolution.height(), 800);
+    /// ```
+    #[must_use]
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    /// Sets [`Resolution::height`].
+    pub fn set_height(&mut self, value: usize) -> &mut Self {
+        self.height = value;
+        self
     }
 }
 

--- a/src/types/stream_data.rs
+++ b/src/types/stream_data.rs
@@ -3,7 +3,6 @@ use core::fmt;
 use std::borrow::Cow;
 
 use derive_builder::Builder;
-use shorthand::ShortHand;
 
 use crate::attribute::AttributePairs;
 use crate::types::{Codecs, HdcpLevel, ProtocolVersion, Resolution};
@@ -14,10 +13,9 @@ use crate::{Error, RequiredVersion};
 /// variants of the [`VariantStream`].
 ///
 /// [`VariantStream`]: crate::tags::VariantStream
-#[derive(ShortHand, Builder, PartialOrd, Debug, Clone, PartialEq, Eq, Hash, Ord)]
+#[derive(Builder, PartialOrd, Debug, Clone, PartialEq, Eq, Hash, Ord)]
 #[builder(setter(strip_option))]
 #[builder(derive(Debug, PartialEq, PartialOrd, Ord, Eq, Hash))]
-#[shorthand(enable(must_use, into))]
 pub struct StreamData<'a> {
     /// The peak segment bitrate of the [`VariantStream`] in bits per second.
     ///
@@ -53,7 +51,6 @@ pub struct StreamData<'a> {
     /// [`MediaSegment`]: crate::MediaSegment
     /// [`MasterPlaylist`]: crate::MasterPlaylist
     /// [`MediaPlaylist`]: crate::MediaPlaylist
-    #[shorthand(disable(into))]
     bandwidth: u64,
     /// The average bandwidth of the stream in bits per second.
     ///
@@ -92,7 +89,6 @@ pub struct StreamData<'a> {
     /// [`MediaPlaylist`]: crate::MediaPlaylist
     /// [`VariantStream`]: crate::tags::VariantStream
     #[builder(default)]
-    #[shorthand(enable(copy), disable(into, option_as_ref))]
     average_bandwidth: Option<u64>,
     /// A list of formats, where each format specifies a media sample type that
     /// is present in one or more renditions specified by the [`VariantStream`].
@@ -158,7 +154,6 @@ pub struct StreamData<'a> {
     ///
     /// [`VariantStream`]: crate::tags::VariantStream
     #[builder(default, setter(into))]
-    #[shorthand(enable(copy))]
     resolution: Option<Resolution>,
     /// High-bandwidth Digital Content Protection level of the
     /// [`VariantStream`].
@@ -181,7 +176,6 @@ pub struct StreamData<'a> {
     ///
     /// [`VariantStream`]: crate::tags::VariantStream
     #[builder(default)]
-    #[shorthand(enable(copy), disable(into))]
     hdcp_level: Option<HdcpLevel>,
     /// It indicates the set of video renditions, that should be used when
     /// playing the presentation.
@@ -234,6 +228,102 @@ impl<'a> StreamData<'a> {
             hdcp_level: None,
             video: None,
         }
+    }
+
+    /// The peak segment bitrate of the [`VariantStream`] in bits per second.
+    ///
+    /// [`VariantStream`]: crate::tags::VariantStream
+    #[must_use]
+    pub fn bandwidth(&self) -> u64 {
+        self.bandwidth
+    }
+
+    /// Sets [`StreamData::bandwidth`].
+    pub fn set_bandwidth(&mut self, value: u64) -> &mut Self {
+        self.bandwidth = value;
+        self
+    }
+
+    /// The average bandwidth of the stream in bits per second.
+    ///
+    /// # Note
+    ///
+    /// This field is optional.
+    #[must_use]
+    pub fn average_bandwidth(&self) -> Option<u64> {
+        self.average_bandwidth
+    }
+
+    /// Sets [`StreamData::average_bandwidth`].
+    pub fn set_average_bandwidth(&mut self, value: Option<u64>) -> &mut Self {
+        self.average_bandwidth = value;
+        self
+    }
+
+    /// A list of formats, where each format specifies a media sample type that
+    /// is present in one or more renditions specified by the [`VariantStream`].
+    ///
+    /// [`VariantStream`]: crate::tags::VariantStream
+    #[must_use]
+    pub fn codecs(&self) -> Option<&Codecs<'a>> {
+        self.codecs.as_ref()
+    }
+
+    /// Sets [`StreamData::codecs`].
+    pub fn set_codecs<V: Into<Codecs<'a>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.codecs = value.map(Into::into);
+        self
+    }
+
+    /// The resolution of the stream.
+    ///
+    /// # Note
+    ///
+    /// This field is optional, but it is recommended if the [`VariantStream`]
+    /// includes video.
+    ///
+    /// [`VariantStream`]: crate::tags::VariantStream
+    #[must_use]
+    pub fn resolution(&self) -> Option<Resolution> {
+        self.resolution
+    }
+
+    /// Sets [`StreamData::resolution`].
+    pub fn set_resolution<V: Into<Resolution>>(&mut self, value: Option<V>) -> &mut Self {
+        self.resolution = value.map(Into::into);
+        self
+    }
+
+    /// High-bandwidth Digital Content Protection level of the
+    /// [`VariantStream`].
+    ///
+    /// [`VariantStream`]: crate::tags::VariantStream
+    #[must_use]
+    pub fn hdcp_level(&self) -> Option<HdcpLevel> {
+        self.hdcp_level
+    }
+
+    /// Sets [`StreamData::hdcp_level`].
+    pub fn set_hdcp_level(&mut self, value: Option<HdcpLevel>) -> &mut Self {
+        self.hdcp_level = value;
+        self
+    }
+
+    /// It indicates the set of video renditions, that should be used when
+    /// playing the presentation.
+    ///
+    /// # Note
+    ///
+    /// This field is optional.
+    #[must_use]
+    pub fn video(&self) -> Option<&Cow<'a, str>> {
+        self.video.as_ref()
+    }
+
+    /// Sets [`StreamData::video`].
+    pub fn set_video<V: Into<Cow<'a, str>>>(&mut self, value: Option<V>) -> &mut Self {
+        self.video = value.map(Into::into);
+        self
     }
 
     /// Returns a builder for [`StreamData`].

--- a/src/types/stream_data.rs
+++ b/src/types/stream_data.rs
@@ -2,8 +2,6 @@ use core::convert::TryFrom;
 use core::fmt;
 use std::borrow::Cow;
 
-use derive_builder::Builder;
-
 use crate::attribute::AttributePairs;
 use crate::types::{Codecs, HdcpLevel, ProtocolVersion, Resolution};
 use crate::utils::{quote, unquote};
@@ -13,9 +11,7 @@ use crate::{Error, RequiredVersion};
 /// variants of the [`VariantStream`].
 ///
 /// [`VariantStream`]: crate::tags::VariantStream
-#[derive(Builder, PartialOrd, Debug, Clone, PartialEq, Eq, Hash, Ord)]
-#[builder(setter(strip_option))]
-#[builder(derive(Debug, PartialEq, PartialOrd, Ord, Eq, Hash))]
+#[derive(PartialOrd, Debug, Clone, PartialEq, Eq, Hash, Ord)]
 pub struct StreamData<'a> {
     /// The peak segment bitrate of the [`VariantStream`] in bits per second.
     ///
@@ -88,7 +84,6 @@ pub struct StreamData<'a> {
     /// [`MasterPlaylist`]: crate::MasterPlaylist
     /// [`MediaPlaylist`]: crate::MediaPlaylist
     /// [`VariantStream`]: crate::tags::VariantStream
-    #[builder(default)]
     average_bandwidth: Option<u64>,
     /// A list of formats, where each format specifies a media sample type that
     /// is present in one or more renditions specified by the [`VariantStream`].
@@ -129,7 +124,6 @@ pub struct StreamData<'a> {
     /// [`VariantStream::ExtXStreamInf`]:
     /// crate::tags::VariantStream::ExtXStreamInf
     /// [RFC6381]: https://tools.ietf.org/html/rfc6381
-    #[builder(default, setter(into))]
     codecs: Option<Codecs<'a>>,
     /// The resolution of the stream.
     ///
@@ -153,7 +147,6 @@ pub struct StreamData<'a> {
     /// includes video.
     ///
     /// [`VariantStream`]: crate::tags::VariantStream
-    #[builder(default, setter(into))]
     resolution: Option<Resolution>,
     /// High-bandwidth Digital Content Protection level of the
     /// [`VariantStream`].
@@ -175,7 +168,6 @@ pub struct StreamData<'a> {
     /// This field is optional.
     ///
     /// [`VariantStream`]: crate::tags::VariantStream
-    #[builder(default)]
     hdcp_level: Option<HdcpLevel>,
     /// It indicates the set of video renditions, that should be used when
     /// playing the presentation.
@@ -204,8 +196,74 @@ pub struct StreamData<'a> {
     /// [`ExtXMedia`]: crate::tags::ExtXMedia
     /// [`MasterPlaylist`]: crate::MasterPlaylist
     /// [`ExtXMedia::media_type`]: crate::tags::ExtXMedia::media_type
-    #[builder(default, setter(into))]
     video: Option<Cow<'a, str>>,
+}
+
+/// Builder for [`StreamData`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StreamDataBuilder<'a> {
+    bandwidth: Option<u64>,
+    average_bandwidth: Option<u64>,
+    codecs: Option<Codecs<'a>>,
+    resolution: Option<Resolution>,
+    hdcp_level: Option<HdcpLevel>,
+    video: Option<Cow<'a, str>>,
+}
+
+impl<'a> StreamDataBuilder<'a> {
+    /// See [`StreamData::bandwidth`].
+    pub fn bandwidth(&mut self, value: u64) -> &mut Self {
+        self.bandwidth = Some(value);
+        self
+    }
+
+    /// See [`StreamData::average_bandwidth`].
+    pub fn average_bandwidth(&mut self, value: u64) -> &mut Self {
+        self.average_bandwidth = Some(value);
+        self
+    }
+
+    /// See [`StreamData::codecs`].
+    pub fn codecs<V: Into<Codecs<'a>>>(&mut self, value: V) -> &mut Self {
+        self.codecs = Some(value.into());
+        self
+    }
+
+    /// See [`StreamData::resolution`].
+    pub fn resolution<V: Into<Resolution>>(&mut self, value: V) -> &mut Self {
+        self.resolution = Some(value.into());
+        self
+    }
+
+    /// See [`StreamData::hdcp_level`].
+    pub fn hdcp_level(&mut self, value: HdcpLevel) -> &mut Self {
+        self.hdcp_level = Some(value);
+        self
+    }
+
+    /// See [`StreamData::video`].
+    pub fn video<V: Into<Cow<'a, str>>>(&mut self, value: V) -> &mut Self {
+        self.video = Some(value.into());
+        self
+    }
+
+    /// Builds a new [`StreamData`].
+    ///
+    /// # Errors
+    ///
+    /// If a required field has not been initialized.
+    pub fn build(&self) -> Result<StreamData<'a>, Error> {
+        Ok(StreamData {
+            bandwidth: self
+                .bandwidth
+                .ok_or_else(|| Error::missing_field("StreamData", "bandwidth"))?,
+            average_bandwidth: self.average_bandwidth,
+            codecs: self.codecs.clone(),
+            resolution: self.resolution,
+            hdcp_level: self.hdcp_level,
+            video: self.video.clone(),
+        })
+    }
 }
 
 impl<'a> StreamData<'a> {


### PR DESCRIPTION
- Drop `derive_builder` and write manual builders for the 8 affected structs (all `build() -> Result<T, Error>`)
- Drop `shorthand` and write the getters/setters by hand
- Remove `Result<_, String>` and `Error::builder()` / `ErrorKind::Builder` left over from the derive_builder integration; validate/build now flow `Error` directly
- Drop `clippy::collapsible_if` and `clippy::module_name_repetitions` from the crate-level `expect`; collapse the affected nested `if` blocks into let-chains

